### PR TITLE
Add sim-hisepq integration test

### DIFF
--- a/.github/workflows/qisa-ci.yml
+++ b/.github/workflows/qisa-ci.yml
@@ -159,16 +159,11 @@ jobs:
 
       # Prebuilt HiSEP-Q RTL testbench for the simulator integration test.
       - name: Provision HiSEP-Q simulator
-        run: ./utils/provision-sim-hisepq
-
-      # FIXME: review this, the path is not ideal.
-      # Both prerequisites above fail *open*: without them lit marks the tests
-      # unsupported and the job stays green. Assert on them so a broken setup
-      # fails loudly instead of quietly dropping test coverage.
-      - name: Verify HiSEP-Q test prerequisites
         run: |
-          command -v ld.lld
-          test -x "$HOME/external/sim-hisepq/bin/sim_hisepq"
+          ./utils/provision-sim-hisepq
+          # Make sure the binary sits at a discoverable path, otherwise tests
+          # which require sim_hisepq might silently be skipped.
+          command -v sim_hisepq
 
       - name: Configure qcc
         run: cmake --preset release -DQCC_ENABLE_HISEPQ=ON -DLLVM_ENABLE_ASSERTIONS=ON

--- a/.github/workflows/qisa-ci.yml
+++ b/.github/workflows/qisa-ci.yml
@@ -84,11 +84,15 @@ jobs:
           restore-keys: |
             ccache-qisa-${{ runner.os }}-${{ runner.arch }}-${{ env.LLVM_CACHE_VERSION }}-
 
-      - name: Install LLVM build dependencies
-        if: steps.llvm-cache.outputs.cache-hit != 'true'
+      # Some tests require `lld` for linking.
+      - name: Install lld
         run: |
           sudo apt-get update
-          sudo apt-get install -y --no-install-recommends ccache clang lld
+          sudo apt-get install -y --no-install-recommends lld
+
+      - name: Install LLVM build dependencies
+        if: steps.llvm-cache.outputs.cache-hit != 'true'
+        run: sudo apt-get install -y --no-install-recommends ccache clang
 
       # Drop large preinstalled toolchains first to maximize available free disk
       # space on our runner.
@@ -152,6 +156,19 @@ jobs:
         with:
           path: ${{ env.LLVM_INSTALL_DIR }}
           key: ${{ steps.llvm-cache.outputs.cache-primary-key }}
+
+      # Prebuilt HiSEP-Q RTL testbench for the simulator integration test.
+      - name: Provision HiSEP-Q simulator
+        run: ./utils/provision-sim-hisepq
+
+      # FIXME: review this, the path is not ideal.
+      # Both prerequisites above fail *open*: without them lit marks the tests
+      # unsupported and the job stays green. Assert on them so a broken setup
+      # fails loudly instead of quietly dropping test coverage.
+      - name: Verify HiSEP-Q test prerequisites
+        run: |
+          command -v ld.lld
+          test -x "$HOME/external/sim-hisepq/bin/sim_hisepq"
 
       - name: Configure qcc
         run: cmake --preset release -DQCC_ENABLE_HISEPQ=ON -DLLVM_ENABLE_ASSERTIONS=ON

--- a/.github/workflows/qisa-ci.yml
+++ b/.github/workflows/qisa-ci.yml
@@ -160,10 +160,7 @@ jobs:
       # Prebuilt HiSEP-Q RTL testbench for the simulator integration test.
       - name: Provision HiSEP-Q simulator
         run: |
-          ./utils/provision-sim-hisepq
-          # Make sure the binary sits at a discoverable path, otherwise tests
-          # which require sim_hisepq might silently be skipped.
-          command -v sim_hisepq
+          ./utils/provision-sim-hisepq --prefix $HOME/.local
 
       - name: Configure qcc
         run: cmake --preset release -DQCC_ENABLE_HISEPQ=ON -DLLVM_ENABLE_ASSERTIONS=ON

--- a/mlir/lib/Target/HiSEPQ/README.md
+++ b/mlir/lib/Target/HiSEPQ/README.md
@@ -25,3 +25,17 @@ Package).
 TODO: Once HiSEP-Q ships a crt0, qcc emits a plain `main`, drops the `_start`
 synthesis, and both files leave this tree. Our future compiler driver likely
 gains a `--sysroot`-style override so an external BSP can take over.
+
+## Simulating
+
+You can download a prebuilt simulator `sim_hisepq` with our
+`utils/provision-sim-hisepq` script. Then use it like so
+
+```shell
+# Run it on the RTL testbench:
+sim_hisepq +MEM_FILE=out.mem
+```
+
+Note that `sim_hisepq` exits 0 unconditionally -- even when it loads no memory
+image at all it still prints `RESULT: PASS`, having executed nothing. Judge a
+run by its instruction trace and event counters, not by its exit status.

--- a/mlir/test/CMakeLists.txt
+++ b/mlir/test/CMakeLists.txt
@@ -5,12 +5,11 @@ else()
   set(QCC_ENABLE_HISEPQ_PY False)
 endif()
 
-# FIXME: review this
 if(QCC_ENABLE_HISEPQ)
   find_program(
     QCC_SIM_HISEPQ_EXECUTABLE
     NAMES sim_hisepq
-    HINTS "$ENV{HOME}/external/sim-hisepq/bin"
+    HINTS "$ENV{HOME}/.local/bin"
     DOC "Path to the prebuilt HiSEP-Q Verilator testbench (sim_hisepq)")
 endif()
 

--- a/mlir/test/CMakeLists.txt
+++ b/mlir/test/CMakeLists.txt
@@ -5,6 +5,15 @@ else()
   set(QCC_ENABLE_HISEPQ_PY False)
 endif()
 
+# FIXME: review this
+if(QCC_ENABLE_HISEPQ)
+  find_program(
+    QCC_SIM_HISEPQ_EXECUTABLE
+    NAMES sim_hisepq
+    HINTS "$ENV{HOME}/external/sim-hisepq/bin"
+    DOC "Path to the prebuilt HiSEP-Q Verilator testbench (sim_hisepq)")
+endif()
+
 configure_lit_site_cfg(${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py
                        MAIN_CONFIG ${CMAKE_CURRENT_SOURCE_DIR}/lit.cfg.py)
 

--- a/mlir/test/lit.cfg.py
+++ b/mlir/test/lit.cfg.py
@@ -1,3 +1,4 @@
+import os
 import shutil
 import sys
 from pathlib import Path
@@ -68,6 +69,14 @@ if not found:
 
 if config.enable_hisepq:
     llvm_config.add_tool_substitutions(["hisepq-elf2mem"], [str(candidate_dir)])
+
+    # Optional prebuilt HiSEP-Q testbench `sim_hisepq`: Provision it with
+    # `utils/provision-sim-hisepq`, or point CMake at your own build via
+    # `-DQCC_SIM_HISEPQ_EXECUTABLE=...`.
+    sim_hisepq = config.sim_hisepq_executable
+    if os.path.isfile(sim_hisepq) and os.access(sim_hisepq, os.X_OK):
+        config.available_features.add("sim-hisepq")
+        config.substitutions.append((r"\bsim_hisepq\b", sim_hisepq))
 
 # Tests opt in via `REQUIRES: lld`.
 if shutil.which("ld.lld", path=config.environment["PATH"]) is not None:

--- a/mlir/test/lit.site.cfg.py.in
+++ b/mlir/test/lit.site.cfg.py.in
@@ -7,6 +7,7 @@ config.project_binary_dir = "@PROJECT_BINARY_DIR@"
 config.project_source_dir = "@PROJECT_SOURCE_DIR@"
 config.cmake_build_type = "@CMAKE_BUILD_TYPE@"
 config.enable_hisepq = @QCC_ENABLE_HISEPQ_PY@
+config.sim_hisepq_executable = "@QCC_SIM_HISEPQ_EXECUTABLE@"
 
 import lit.llvm
 lit.llvm.initialize(lit_config, config)

--- a/mlir/test/tools/qcc/target-hisepq/simulate.mlir
+++ b/mlir/test/tools/qcc/target-hisepq/simulate.mlir
@@ -1,0 +1,30 @@
+// REQUIRES: lld, sim-hisepq
+
+// Full HiSEP-Q integration test: compile, link, convert to memory image, then
+// actually execute that image on the prebuilt RTL testbench.
+
+// RUN: qcc --target=hisepq --compile-to=native --binary %s -o %t.o
+// RUN: ld.lld -T %project_source_dir/mlir/lib/Target/HiSEPQ/Scripts/hisepq.ld %t.o -o %t.elf
+// RUN: hisepq-elf2mem %t.elf -o %t.mem
+// RUN: sim_hisepq +MEM_FILE=%t.mem | FileCheck %s
+
+func.func @main() attributes { qcc.entry_point } {
+    %0 = qc.static 0 : !qc.qubit
+    qc.h %0 : !qc.qubit
+    %m = qc.measure %0 : !qc.qubit -> i1
+    aux.record_int %m : i1
+    return
+}
+
+// `sim_hisepq` exits 0 unconditionally -- with no memory image at all it still
+// reports `RESULT: PASS`, having executed nothing. So we have to assert on the
+// trace and on the event counters.
+
+// FIXME: watch out for things to also check
+
+// CHECK:      [INIT] mem file:
+// CHECK:      [INSTR] 00001537  lui a0, 0x1
+// CHECK:      [MEASURE] qvsg_meas=1 start
+// CHECK:      quantum events : 2
+// CHECK-NEXT: qubit fires    : 2
+// CHECK-NEXT: FIFO errors    : 0

--- a/mlir/test/tools/qcc/target-hisepq/simulate.mlir
+++ b/mlir/test/tools/qcc/target-hisepq/simulate.mlir
@@ -1,12 +1,27 @@
 // REQUIRES: lld, sim-hisepq
 
-// Full HiSEP-Q integration test: compile, link, convert to memory image, then
-// actually execute that image on the prebuilt RTL testbench.
+// Full HiSEP-Q integration test: compile, link, convert to a memory image, then actually execute that image on the
+// prebuilt RTL testbench.
 
 // RUN: qcc --target=hisepq --compile-to=native --binary %s -o %t.o
 // RUN: ld.lld -T %project_source_dir/mlir/lib/Target/HiSEPQ/Scripts/hisepq.ld %t.o -o %t.elf
 // RUN: hisepq-elf2mem %t.elf -o %t.mem
-// RUN: sim_hisepq +MEM_FILE=%t.mem | FileCheck %s
+// RUN: sim_hisepq +MEM_FILE=%t.mem > %t.log
+
+// Split checks into three stages for readability.
+// RUN: FileCheck --check-prefix=CHECK-ISSUE --input-file=%t.log %s
+// RUN: FileCheck --check-prefix=CHECK-STREAM --input-file=%t.log %s
+// RUN: FileCheck --check-prefix=CHECK-AWG --input-file=%t.log %s
+
+// ISSUE Stage: Ibex decodes classical and quantum instructions and hands over the vector and quantum ones to the
+// vector coprocessor (vproc).
+
+// STREAM Stage: vproc serializes a quantum instruction into quantum *events*, one per vector element. Hence one
+// instruction on N qubits becomes N events in the stream. Each event carries op type (e.g. SINGLE, PAIR),
+// instruction id, elem1/2/3 (qubit indices, gate ids, timing info).
+
+// AWG Stage: The quantum_dispatcher consumes the event stream and drops each event into a per-qubit timed FIFO, and
+// fires it when the global counter t_cnt reaches its scheduled slot. The "qubit fires" counter counts the pulses.
 
 func.func @main() attributes { qcc.entry_point } {
     %0 = qc.static 0 : !qc.qubit
@@ -16,15 +31,25 @@ func.func @main() attributes { qcc.entry_point } {
     return
 }
 
-// `sim_hisepq` exits 0 unconditionally -- with no memory image at all it still
-// reports `RESULT: PASS`, having executed nothing. So we have to assert on the
-// trace and on the event counters.
+// CHECK-ISSUE: [MEASURE] qvsg_meas=1 start
+// TODO(HiSEP-Q): In addition, there should be two [INSTR] lines here for the two gates (H and MZ). Unfortunately, the
+// simulator only matches the *full* 32-bit instruction words (containing specific operands) as in their own Bell demo.
 
-// FIXME: watch out for things to also check
+// TODO(HiSEP-Q): qvsg_meas=1 start actually freezes the core until measure_done arrives, and it never does. The
+// testbench sends it only once the measure stream reaches qsg_measure_elem_budget(lmul), which is 8 events even at the
+// smallest LMUL, whereas a single-qubit measure emits one. So the run ends on "200 idle cycles after last event"
+// instead of resuming. Their own demo/bell_generic.mem stops at the same point.
 
-// CHECK:      [INIT] mem file:
-// CHECK:      [INSTR] 00001537  lui a0, 0x1
-// CHECK:      [MEASURE] qvsg_meas=1 start
-// CHECK:      quantum events : 2
-// CHECK-NEXT: qubit fires    : 2
-// CHECK-NEXT: FIFO errors    : 0
+// Event stream leaving vproc, gate id in `elem3[31:25]` (7 uppermost bits). Note that the first seven bits of
+// 0xc8 are indeed 0x64 (Hadamard).
+
+// CHECK-STREAM: [QX_START] {{.*}} elem3=c8000000
+// CHECK-STREAM: [QX_START] {{.*}} elem3=d0000000
+// CHECK-STREAM: quantum events : 2
+
+// Pulses reaching qubit 0: Hadamard, then measure.
+
+// CHECK-AWG:      [AWG]{{.*}} qubit[00]  gate=0x64  role=CTRL
+// CHECK-AWG:      [AWG]{{.*}} qubit[00]  gate=0x68  role=CTRL
+// CHECK-AWG:      qubit fires    : 2
+// CHECK-AWG-NEXT: FIFO errors    : 0

--- a/utils/provision-sim-hisepq
+++ b/utils/provision-sim-hisepq
@@ -8,17 +8,18 @@ ASSET_REPO=FullStaQD/prebuilt-artifacts
 # FIXME: reconsider this
 PREFIX_DEFAULT=$HOME/external/sim-hisepq
 
-# FIXME: use the sha of the file sim_hisepq itself.
-# SHA256 of `$TAG-<os>-<arch>.tar.gz`, one variable per published platform. Add
-# a line here when the companion repo starts shipping another platform.
-SHA256_linux_x86_64=f59e5e67e48cc2b9a21fb5996533676e7ca41a959966da22101cb11ddd3c315d
+# SHA256 of the `sim_hisepq` executable itself, one variable per published
+# platform. Add a line here when the asset repo starts shipping another
+# platform.
+SHA256_linux_x86_64=791722ec760418b806f941b536c88095499fe2452e3283742d316decf9cd324f
 
 usage() {
   cat <<EOF
 Usage: ${0##*/} [--prefix PREFIX] [--force]
 
-Download the prebuilt HiSEP-Q simulator (\`sim_hisepq\`) from our companion
-repo, verify it against the pinned SHA256, and install it as PREFIX/bin/sim_hisepq.
+Download the prebuilt HiSEP-Q simulator (\`sim_hisepq\`) from our asset
+repo, verify the executable against its pinned SHA256, and install it as
+PREFIX/bin/sim_hisepq.
 
   repo:    https://github.com/$ASSET_REPO
   release: $TAG
@@ -83,10 +84,9 @@ x86_64 | amd64) ARCH=x86_64 ;;
 *) ARCH=unsupported ;;
 esac
 
-# FIXME: verify this.
 CHECKSUM_VAR="SHA256_${OS}_${ARCH}"
 if [[ -z "${!CHECKSUM_VAR:-}" ]]; then
-  # Derive the supported list from the checksums we actually pin.
+  # Derive the supported list from the checksums we pinned above.
   SUPPORTED=$(compgen -A variable SHA256_ | sed 's/^SHA256_//; s/_/-/' | tr '\n' ' ')
   echo "${0##*/}: no prebuilt sim_hisepq for $(uname -s)-$(uname -m)." >&2
   echo "Release $TAG ships: ${SUPPORTED% }" >&2
@@ -111,16 +111,17 @@ echo "Downloading $URL"
 curl --fail --location --silent --show-error --proto '=https' --tlsv1.2 \
   -o "$TMP/$ASSET" "$URL"
 
-ACTUAL=$(sha256sum "$TMP/$ASSET" | cut -d' ' -f1)
+# Extract the one archive member (sim_hisepq) we expect:
+tar -xzf "$TMP/$ASSET" -C "$TMP" --no-same-owner sim_hisepq
+
+ACTUAL=$(sha256sum "$TMP/sim_hisepq" | cut -d' ' -f1)
 if [[ "$ACTUAL" != "${!CHECKSUM_VAR}" ]]; then
-  echo "${0##*/}: SHA256 mismatch for $ASSET, refusing to install." >&2
+  echo "${0##*/}: SHA256 mismatch for sim_hisepq from $ASSET, refusing to install." >&2
   echo "  expected: ${!CHECKSUM_VAR}" >&2
   echo "  actual:   $ACTUAL" >&2
   exit 1
 fi
 
-# The tarball is flat: a single `sim_hisepq` executable.
-tar -xzf "$TMP/$ASSET" -C "$TMP"
 install -D -m 0755 "$TMP/sim_hisepq" "$EXE"
 echo "$TAG" >"$STAMP"
 

--- a/utils/provision-sim-hisepq
+++ b/utils/provision-sim-hisepq
@@ -5,8 +5,7 @@ set -euo pipefail
 TAG=sim-hisepq-20260619-g817e42e-r1
 ASSET_REPO=FullStaQD/prebuilt-artifacts
 
-# FIXME: reconsider this
-PREFIX_DEFAULT=$HOME/external/sim-hisepq
+PREFIX_DEFAULT=$HOME/.local
 
 # SHA256 of the `sim_hisepq` executable itself, one variable per published
 # platform. Add a line here when the asset repo starts shipping another
@@ -36,8 +35,7 @@ PATH. From elsewhere, configure with
 
 Options:
   --prefix PREFIX   Directory to install into. The executable ends up in PREFIX/bin.
-                    Defaults to
-                    $PREFIX_DEFAULT.
+                    Defaults to $PREFIX_DEFAULT.
   --force           Reinstall even if the pinned release is already installed.
   -h, --help        Show this message.
 EOF
@@ -93,10 +91,11 @@ if [[ -z "${!CHECKSUM_VAR:-}" ]]; then
   exit 1
 fi
 
-STAMP="$PREFIX/.sim-hisepq.tag"
 EXE="$PREFIX/bin/sim_hisepq"
 
-if [[ "$FORCE" == false && -x "$EXE" && "$(cat "$STAMP" 2>/dev/null)" == "$TAG" ]]; then
+# Skip install if if not forced and checksum already fits.
+if [[ "$FORCE" == false && -x "$EXE" &&
+  "$(sha256sum "$EXE" | cut -d' ' -f1)" == "${!CHECKSUM_VAR}" ]]; then
   echo "$TAG already installed at $EXE, skipping."
   exit 0
 fi
@@ -123,6 +122,5 @@ if [[ "$ACTUAL" != "${!CHECKSUM_VAR}" ]]; then
 fi
 
 install -D -m 0755 "$TMP/sim_hisepq" "$EXE"
-echo "$TAG" >"$STAMP"
 
 echo "Installed $TAG to $EXE"

--- a/utils/provision-sim-hisepq
+++ b/utils/provision-sim-hisepq
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+TAG=sim-hisepq-20260619-g817e42e-r1
+ASSET_REPO=FullStaQD/prebuilt-artifacts
+
+# FIXME: reconsider this
+PREFIX_DEFAULT=$HOME/external/sim-hisepq
+
+# FIXME: use the sha of the file sim_hisepq itself.
+# SHA256 of `$TAG-<os>-<arch>.tar.gz`, one variable per published platform. Add
+# a line here when the companion repo starts shipping another platform.
+SHA256_linux_x86_64=f59e5e67e48cc2b9a21fb5996533676e7ca41a959966da22101cb11ddd3c315d
+
+usage() {
+  cat <<EOF
+Usage: ${0##*/} [--prefix PREFIX] [--force]
+
+Download the prebuilt HiSEP-Q simulator (\`sim_hisepq\`) from our companion
+repo, verify it against the pinned SHA256, and install it as PREFIX/bin/sim_hisepq.
+
+  repo:    https://github.com/$ASSET_REPO
+  release: $TAG
+
+Only platforms the pinned release ships are supported; on any other host this
+fails instead of installing something untested.
+
+Re-running is a no-op once the pinned release is installed. Bumping the pinned
+release (or passing --force) makes the next run reinstall.
+
+CMake finds the simulator automatically at the default prefix or anywhere on
+PATH. From elsewhere, configure with
+\`-DQCC_SIM_HISEPQ_EXECUTABLE=PREFIX/bin/sim_hisepq\`.
+
+Options:
+  --prefix PREFIX   Directory to install into. The executable ends up in PREFIX/bin.
+                    Defaults to
+                    $PREFIX_DEFAULT.
+  --force           Reinstall even if the pinned release is already installed.
+  -h, --help        Show this message.
+EOF
+}
+
+PREFIX=$PREFIX_DEFAULT
+FORCE=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+  -h | --help)
+    usage
+    exit 0
+    ;;
+  --prefix)
+    [[ $# -ge 2 ]] || { echo "${0##*/}: --prefix requires an argument" >&2; exit 1; }
+    PREFIX=$2
+    shift 2
+    ;;
+  --prefix=*)
+    PREFIX=${1#--prefix=}
+    shift
+    ;;
+  --force)
+    FORCE=true
+    shift
+    ;;
+  *)
+    echo "${0##*/}: unknown argument: $1" >&2
+    usage >&2
+    exit 1
+    ;;
+  esac
+done
+
+# Normalize the host platform to the naming scheme used by the release assets.
+case "$(uname -s)" in
+Linux) OS=linux ;;
+*) OS=unsupported ;;
+esac
+
+case "$(uname -m)" in
+x86_64 | amd64) ARCH=x86_64 ;;
+*) ARCH=unsupported ;;
+esac
+
+# FIXME: verify this.
+CHECKSUM_VAR="SHA256_${OS}_${ARCH}"
+if [[ -z "${!CHECKSUM_VAR:-}" ]]; then
+  # Derive the supported list from the checksums we actually pin.
+  SUPPORTED=$(compgen -A variable SHA256_ | sed 's/^SHA256_//; s/_/-/' | tr '\n' ' ')
+  echo "${0##*/}: no prebuilt sim_hisepq for $(uname -s)-$(uname -m)." >&2
+  echo "Release $TAG ships: ${SUPPORTED% }" >&2
+  exit 1
+fi
+
+STAMP="$PREFIX/.sim-hisepq.tag"
+EXE="$PREFIX/bin/sim_hisepq"
+
+if [[ "$FORCE" == false && -x "$EXE" && "$(cat "$STAMP" 2>/dev/null)" == "$TAG" ]]; then
+  echo "$TAG already installed at $EXE, skipping."
+  exit 0
+fi
+
+ASSET="$TAG-$OS-$ARCH.tar.gz"
+URL="https://github.com/$ASSET_REPO/releases/download/$TAG/$ASSET"
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+echo "Downloading $URL"
+curl --fail --location --silent --show-error --proto '=https' --tlsv1.2 \
+  -o "$TMP/$ASSET" "$URL"
+
+ACTUAL=$(sha256sum "$TMP/$ASSET" | cut -d' ' -f1)
+if [[ "$ACTUAL" != "${!CHECKSUM_VAR}" ]]; then
+  echo "${0##*/}: SHA256 mismatch for $ASSET, refusing to install." >&2
+  echo "  expected: ${!CHECKSUM_VAR}" >&2
+  echo "  actual:   $ACTUAL" >&2
+  exit 1
+fi
+
+# The tarball is flat: a single `sim_hisepq` executable.
+tar -xzf "$TMP/$ASSET" -C "$TMP"
+install -D -m 0755 "$TMP/sim_hisepq" "$EXE"
+echo "$TAG" >"$STAMP"
+
+echo "Installed $TAG to $EXE"


### PR DESCRIPTION
- Added `provision-sim-hisepq` to install `sim_hisepq` to simulate a memory image.
- Added corresponding test case for QCC x HiSEP-Q integration
- Updated cmake, lit config, and CI to auto install and discover `sim_hisepq`.

Assisted-by: Claude Code