### PR TITLE
Upgrade mqt-core dependency

### DIFF
--- a/mlir/cmake/ExternalDependencies.cmake
+++ b/mlir/cmake/ExternalDependencies.cmake
@@ -4,7 +4,7 @@ set(FETCH_PACKAGES "")
 FetchContent_Declare(
   mqt-core
   GIT_REPOSITORY https://github.com/munich-quantum-toolkit/core.git
-  GIT_TAG 767a6eb77e2a165b8752eda97575b5a4deeb5203 # Date:   Wed Apr 1 20:05:00 2026 +0200
+  GIT_TAG 25b7eb8ef50db57abe0de94044821a160f384b89 # Date:   Fri Aug 28 00:41:57 2026 +0200
 )
 list(APPEND FETCH_PACKAGES mqt-core)
 

--- a/mlir/lib/Conversion/JaspToQC/JaspToQC.cpp
+++ b/mlir/lib/Conversion/JaspToQC/JaspToQC.cpp
@@ -302,10 +302,13 @@ private:
       QCOp::create(rewriter, op.getLoc(), operands[targetOperandIndices]...,
                    operands[paramOperandIndices + paramIndexOffset]...);
     } else {
-      qc::CtrlOp::create(rewriter, op.getLoc(), operands.take_front(numControls), [&]() {
-        QCOp::create(rewriter, op.getLoc(), operands[targetOperandIndices + targetIndexOffset]...,
-                     operands[paramOperandIndices + paramIndexOffset]...);
-      });
+      // `qc.ctrl` takes its targets as operands and aliases them to the block arguments of its
+      // body region, so the nested gate must be built on those block arguments.
+      qc::CtrlOp::create(rewriter, op.getLoc(), operands.take_front(numControls),
+                         operands.slice(targetIndexOffset, numTargets), [&](ValueRange targets) {
+                           QCOp::create(rewriter, op.getLoc(), targets[targetOperandIndices]...,
+                                        operands[paramOperandIndices + paramIndexOffset]...);
+                         });
     }
 
     rewriter.eraseOp(op);

--- a/mlir/lib/Conversion/ToQIR/ConvertQCToQIR.cpp
+++ b/mlir/lib/Conversion/ToQIR/ConvertQCToQIR.cpp
@@ -64,7 +64,10 @@ static StringRef mapUnitaryToQIS(qc::UnitaryOpInterface unitaryOp) {
 
   if (unitaryOp.getNumControls() == 1) {
     auto ctrlOp = cast<qc::CtrlOp>(unitaryOp);
-    auto bodyOp = ctrlOp.getBodyUnitary();
+    if (ctrlOp.getNumBodyUnitaries() != 1) {
+      return "";
+    }
+    auto bodyOp = ctrlOp.getBodyUnitary(0);
 
     return llvm::TypeSwitch<Operation*, StringRef>(bodyOp)
         .Case<qc::XOp>([](auto) { return qcc::qirQisCX; })

--- a/mlir/lib/Conversion/ToQIR/ConvertQCToQIR.cpp
+++ b/mlir/lib/Conversion/ToQIR/ConvertQCToQIR.cpp
@@ -256,6 +256,10 @@ struct UnitaryLowering : public ConversionPattern {
     auto moduleOp = op->getParentOfType<ModuleOp>();
 
     auto qisName = mapUnitaryToQIS(unitaryOp);
+    if (qisName.empty()) {
+      return failure(); // diagnostic handled by legalizer
+    }
+
     auto fnDecl = moduleOp.lookupSymbol<LLVM::LLVMFuncOp>(qisName);
     if (!fnDecl) {
       return emitMissingQIRDeclError(unitaryOp, qisName);

--- a/mlir/lib/Target/QIR/CMakeLists.txt
+++ b/mlir/lib/Target/QIR/CMakeLists.txt
@@ -14,6 +14,5 @@ add_mlir_library(
   MLIRQCDialect
   # Passes
   MLIRArithTransforms
-  MLIRQCToQIR
   QCCAuxOutputRecording
   QCCToQIR)

--- a/mlir/test/tools/qcc-opt/ToQIR/convert-qc-to-qir-error.mlir
+++ b/mlir/test/tools/qcc-opt/ToQIR/convert-qc-to-qir-error.mlir
@@ -1,0 +1,15 @@
+// RUN: qcc-opt %s -convert-qc-to-qir --split-input-file --verify-diagnostics
+
+/// A gate outside the supported native gate set has no QIR mapping.
+func.func @unsupported_gate() attributes { qcc.entry_point } {
+  %q0 = qc.static 0 : !qc.qubit
+  %q1 = qc.static 1 : !qc.qubit
+
+  // expected-error @+1 {{failed to legalize operation 'qc.swap'}}
+  qc.swap %q0, %q1 : !qc.qubit, !qc.qubit
+
+  return
+}
+
+llvm.func @__quantum__rt__initialize(!llvm.ptr)
+llvm.func @__quantum__qis__x__body(!llvm.ptr)

--- a/mlir/test/tools/qcc-opt/ToQIR/convert-qc-to-qir.mlir
+++ b/mlir/test/tools/qcc-opt/ToQIR/convert-qc-to-qir.mlir
@@ -29,7 +29,10 @@ func.func @test() -> i64 attributes { qcc.entry_point } {
     // CHECK:           %[[QC5:.*]] = llvm.mlir.constant(5 : i64) : i64
     // CHECK:           %[[QP5:.*]] = llvm.inttoptr %[[QC5]] : i64 to !llvm.ptr
     // CHECK:           llvm.call @__quantum__qis__x__body(%[[QP5]]) : (!llvm.ptr) -> ()
-    qc.ctrl(%q5) { qc.x %q7 : !qc.qubit } : !qc.qubit
+    qc.ctrl(%q5) targets(%t7 = %q7) {
+      qc.x %t7 : !qc.qubit
+      qc.yield
+    } : {!qc.qubit}, {!qc.qubit}
     // CHECK-DAG:       %[[QC3:.*]] = llvm.mlir.constant(5 : i64) : i64
     // CHECK-DAG:       %[[QP3:.*]] = llvm.inttoptr %[[QC3]] : i64 to !llvm.ptr
     // CHECK-DAG:       %[[QC7:.*]] = llvm.mlir.constant(7 : i64) : i64

--- a/mlir/test/tools/qcc-opt/jasp-convert-memref-to-static-qubits-test.mlir
+++ b/mlir/test/tools/qcc-opt/jasp-convert-memref-to-static-qubits-test.mlir
@@ -9,13 +9,15 @@ func.func public @test(){
     %0 = memref.load %alloc[%c0] : memref<3x!qc.qubit>
     qc.h %0 : !qc.qubit
     %1 = memref.load %alloc[%c1] : memref<3x!qc.qubit>
-    qc.ctrl(%0) {
-      qc.x %1 : !qc.qubit
-    } : !qc.qubit
+    qc.ctrl(%0) targets(%t1 = %1) {
+      qc.x %t1 : !qc.qubit
+      qc.yield
+    } : {!qc.qubit}, {!qc.qubit}
     %2 = memref.load %alloc[%c2] : memref<3x!qc.qubit>
-    qc.ctrl(%1) {
-      qc.x %2 : !qc.qubit
-    } : !qc.qubit
+    qc.ctrl(%1) targets(%t2 = %2) {
+      qc.x %t2 : !qc.qubit
+      qc.yield
+    } : {!qc.qubit}, {!qc.qubit}
     %3 = qc.measure %0 : !qc.qubit -> i1
     %4 = qc.measure %1 : !qc.qubit -> i1
     %5 = qc.measure %2 : !qc.qubit -> i1
@@ -28,12 +30,14 @@ func.func public @test(){
 // CHECK:     %[[Q1:.*]] = qc.static 1 : !qc.qubit
 // CHECK:     %[[Q2:.*]] = qc.static 2 : !qc.qubit
 // CHECK:     qc.h %[[Q0]] : !qc.qubit
-// CHECK:     qc.ctrl(%[[Q0]]) {
-// CHECK:       qc.x %[[Q1]] : !qc.qubit
-// CHECK:     } : !qc.qubit
-// CHECK:     qc.ctrl(%[[Q1]]) {
-// CHECK:       qc.x %[[Q2]] : !qc.qubit
-// CHECK:     } : !qc.qubit
+// CHECK:     qc.ctrl(%[[Q0]]) targets (%[[T_Q1:.*]] = %[[Q1]]) {
+// CHECK:       qc.x %[[T_Q1]] : !qc.qubit
+// CHECK:       qc.yield
+// CHECK:     } : {{.*!qc.qubit.*!qc.qubit.*}}
+// CHECK:     qc.ctrl(%[[Q1]]) targets (%[[T_Q2:.*]] = %[[Q2]]) {
+// CHECK:       qc.x %[[T_Q2]] : !qc.qubit
+// CHECK:       qc.yield
+// CHECK:     } : {{.*!qc.qubit.*!qc.qubit.*}}
 // CHECK:     %[[M0:.*]] = qc.measure %[[Q0]] : !qc.qubit -> i1
 // CHECK:     %[[M1:.*]] = qc.measure %[[Q1]] : !qc.qubit -> i1
 // CHECK:     %[[M2:.*]] = qc.measure %[[Q2]] : !qc.qubit -> i1

--- a/mlir/test/tools/qcc-opt/jasp-to-qc-gates-test.mlir
+++ b/mlir/test/tools/qcc-opt/jasp-to-qc-gates-test.mlir
@@ -58,22 +58,27 @@ module @jasp_module {
 // CHECK:           qc.ry({{.*}}) [[Q0]] : !qc.qubit
 // CHECK:           qc.rz({{.*}}) [[Q0]] : !qc.qubit
 // CHECK:           qc.u({{.*}}, {{.*}}, {{.*}}) [[Q0]] : !qc.qubit
-// CHECK:           qc.ctrl([[Q0]]) {
-// CHECK:             qc.x [[Q1]] : !qc.qubit
-// CHECK:           } : !qc.qubit
-// CHECK:           qc.ctrl([[Q0]]) {
-// CHECK:             qc.y [[Q1]] : !qc.qubit
-// CHECK:           } : !qc.qubit
-// CHECK:           qc.ctrl([[Q0]]) {
-// CHECK:             qc.z [[Q1]] : !qc.qubit
-// CHECK:           } : !qc.qubit
+// CHECK:           qc.ctrl([[Q0]]) targets ([[T_X:%.+]] = [[Q1]]) {
+// CHECK:             qc.x [[T_X]] : !qc.qubit
+// CHECK:             qc.yield
+// CHECK:           } : {{.*!qc.qubit.*!qc.qubit.*}}
+// CHECK:           qc.ctrl([[Q0]]) targets ([[T_Y:%.+]] = [[Q1]]) {
+// CHECK:             qc.y [[T_Y]] : !qc.qubit
+// CHECK:             qc.yield
+// CHECK:           } : {{.*!qc.qubit.*!qc.qubit.*}}
+// CHECK:           qc.ctrl([[Q0]]) targets ([[T_Z:%.+]] = [[Q1]]) {
+// CHECK:             qc.z [[T_Z]] : !qc.qubit
+// CHECK:             qc.yield
+// CHECK:           } : {{.*!qc.qubit.*!qc.qubit.*}}
 // CHECK:           qc.swap [[Q0]], [[Q1]] : !qc.qubit, !qc.qubit
-// CHECK:           qc.ctrl([[Q0]]) {
-// CHECK:             qc.p({{.*}}) [[Q1]] : !qc.qubit
-// CHECK:           } : !qc.qubit
-// CHECK:           qc.ctrl([[Q0]]) {
-// CHECK:             qc.rz({{.*}}) [[Q1]] : !qc.qubit
-// CHECK:           } : !qc.qubit
+// CHECK:           qc.ctrl([[Q0]]) targets ([[T_P:%.+]] = [[Q1]]) {
+// CHECK:             qc.p({{.*}}) [[T_P]] : !qc.qubit
+// CHECK:             qc.yield
+// CHECK:           } : {{.*!qc.qubit.*!qc.qubit.*}}
+// CHECK:           qc.ctrl([[Q0]]) targets ([[T_RZ:%.+]] = [[Q1]]) {
+// CHECK:             qc.rz({{.*}}) [[T_RZ]] : !qc.qubit
+// CHECK:             qc.yield
+// CHECK:           } : {{.*!qc.qubit.*!qc.qubit.*}}
 // CHECK:           qc.rxx({{.*}}) [[Q0]], [[Q1]] : !qc.qubit, !qc.qubit
 // CHECK:           qc.rzz({{.*}}) [[Q0]], [[Q1]] : !qc.qubit, !qc.qubit
 // CHECK:           qc.xx_plus_yy({{.*}}, {{.*}}) [[Q0]], [[Q1]] : !qc.qubit, !qc.qubit

--- a/mlir/test/tools/qcc-opt/mqt-core-integration-test.mlir
+++ b/mlir/test/tools/qcc-opt/mqt-core-integration-test.mlir
@@ -1,7 +1,7 @@
 // RUN: qcc-opt %s | FileCheck %s
 module {
   func.func @main() -> i64 attributes {passthrough = ["entry_point"]} {
-    %0 = qc.alloc("q", 1, 0) : !qc.qubit
+    %0 = qc.alloc : !qc.qubit
     qc.x %0 : !qc.qubit
     qc.dealloc %0 : !qc.qubit
     %c0_i64 = arith.constant 0 : i64
@@ -10,7 +10,7 @@ module {
 }
 
 // CHECK-LABEL: @main
-// CHECK: [[q0:%.+]] = qc.alloc("q", 1, 0) : !qc.qubit
+// CHECK: [[q0:%.+]] = qc.alloc : !qc.qubit
 // CHECK: qc.x [[q0]] : !qc.qubit
 // CHECK: qc.dealloc [[q0]] : !qc.qubit
 // CHECK: [[c0_i64:%.+]] = arith.constant 0 : i64

--- a/mlir/test/tools/qcc-opt/output-recording.mlir
+++ b/mlir/test/tools/qcc-opt/output-recording.mlir
@@ -91,7 +91,7 @@ func.func @test_multiple_returns() -> (i64, i1) attributes { qcc.entry_point } {
 
 // expected-error @+1 {{Return types other than integers}}
 func.func @test_unsupported_returns() -> (!qc.qubit, i1) attributes { qcc.entry_point } {
-  %0 = qc.alloc("q", 1, 0) : !qc.qubit
+  %0 = qc.alloc : !qc.qubit
   %1 = arith.constant 1 : i1
 
   return %0, %1 : !qc.qubit, i1

--- a/mlir/test/tools/qcc/target-hisepq/smoke.mlir
+++ b/mlir/test/tools/qcc/target-hisepq/smoke.mlir
@@ -8,8 +8,10 @@ func.func @main() attributes { qcc.entry_point } {
 
     qc.h %0 : !qc.qubit
 
-    qc.ctrl(%0) { qc.x %1 : !qc.qubit } : !qc.qubit
-    qc.ctrl(%1) { qc.x %2 : !qc.qubit } : !qc.qubit
+    qc.ctrl(%0) targets(%t0 = %1) { qc.x %t0 : !qc.qubit
+                                   qc.yield } : {!qc.qubit}, {!qc.qubit}
+    qc.ctrl(%1) targets(%t1 = %2) { qc.x %t1 : !qc.qubit
+                                   qc.yield } : {!qc.qubit}, {!qc.qubit}
 
     %m0 = qc.measure %0 : !qc.qubit -> i1
     %m1 = qc.measure %1 : !qc.qubit -> i1


### PR DESCRIPTION
The essential change is in `mlir/cmake/ExternalDependencies.cmake`. Anything else is just update churn.