### PR TITLE
Upgrade to llvm version 23.1.0

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -20,4 +20,4 @@ RUN uv tool install cmake && \
 
 # Downloads and installs a prebuilt LLVM/MLIR toolchain for the current OS and architecture. Uses `zstd`.
 RUN curl -LsSf https://github.com/munich-quantum-software/setup-mlir/releases/latest/download/setup-mlir.sh \
-  | bash -s -- -v 22.1.7 -p /opt/llvm
+  | bash -s -- -v 23.1.0 -p /opt/llvm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   change-detection:
     name: 🔍 Change
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-change-detection.yml@b17932e07095e11c8f8c0d74298bbcde43f77a15 # v2.1.1
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-change-detection.yml@063c90c8e7e094bfffb73f8436eb55341c1e820f # v2.3.0
 
   cpp-tests-ubuntu:
     name: 🇨‌ Test 🐧
@@ -33,7 +33,7 @@ jobs:
           - runs-on: ubuntu-24.04
             compiler: gcc
             preset: debug
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-ubuntu.yml@b17932e07095e11c8f8c0d74298bbcde43f77a15 # v2.1.1
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-ubuntu.yml@063c90c8e7e094bfffb73f8436eb55341c1e820f # v2.3.0
     with:
       runs-on: ${{ matrix.runs-on }}
       compiler: ${{ matrix.compiler }}
@@ -55,7 +55,7 @@ jobs:
           - runs-on: macos-26
             compiler: clang
             preset: debug
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-macos.yml@b17932e07095e11c8f8c0d74298bbcde43f77a15 # v2.1.1
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-macos.yml@063c90c8e7e094bfffb73f8436eb55341c1e820f # v2.3.0
     with:
       runs-on: ${{ matrix.runs-on }}
       compiler: ${{ matrix.compiler }}
@@ -77,7 +77,7 @@ jobs:
           - runs-on: windows-2025
             compiler: msvc
             preset: debug-windows
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-windows.yml@b17932e07095e11c8f8c0d74298bbcde43f77a15 # v2.1.1
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-tests-windows.yml@063c90c8e7e094bfffb73f8436eb55341c1e820f # v2.3.0
     with:
       runs-on: ${{ matrix.runs-on }}
       compiler: ${{ matrix.compiler }}
@@ -91,7 +91,7 @@ jobs:
     name: 🇨‌ Lint
     needs: change-detection
     if: fromJSON(needs.change-detection.outputs.run-cpp-linter)
-    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-linter.yml@b17932e07095e11c8f8c0d74298bbcde43f77a15 # v2.1.1
+    uses: munich-quantum-toolkit/workflows/.github/workflows/reusable-cpp-linter.yml@063c90c8e7e094bfffb73f8436eb55341c1e820f # v2.3.0
     with:
       clang-version: 22
       build-project: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
       runs-on: ${{ matrix.runs-on }}
       compiler: ${{ matrix.compiler }}
       setup-mlir: true
-      llvm-version: 22.1.7
+      llvm-version: 23.1.0
       preset-name: ${{ matrix.preset }}
 
   cpp-tests-windows:
@@ -82,7 +82,7 @@ jobs:
       runs-on: ${{ matrix.runs-on }}
       compiler: ${{ matrix.compiler }}
       setup-mlir: true
-      llvm-version: 22.1.7
+      llvm-version: 23.1.0
       mlir-debug: ${{ matrix.preset == 'debug-windows' }}
       preset-name: ${{ matrix.preset }}
 
@@ -101,7 +101,7 @@ jobs:
       # this job does not have.
       cpp-linter-ignore-extra: "mlir/lib/Target/HiSEPQ/**"
       setup-mlir: true
-      llvm-version: 22.1.7
+      llvm-version: 23.1.0
     permissions:
       contents: read # Needed to fetch code
       pull-requests: write # Needed to post PR comments

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runs-on: [macos-26, macos-26-intel]
+        runs-on: [macos-26]
         compiler: [clang]
         preset: [release]
         include:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       runs-on: ${{ matrix.runs-on }}
       compiler: ${{ matrix.compiler }}
       setup-mlir: true
-      llvm-version: 22.1.7
+      llvm-version: 23.1.0
       preset-name: ${{ matrix.preset }}
 
   cpp-tests-macos:

--- a/mlir/cmake/ExternalDependencies.cmake
+++ b/mlir/cmake/ExternalDependencies.cmake
@@ -4,7 +4,7 @@ set(FETCH_PACKAGES "")
 FetchContent_Declare(
   mqt-core
   GIT_REPOSITORY https://github.com/munich-quantum-toolkit/core.git
-  GIT_TAG efbba8902710cebae60e865ef031df146a5868bf # Date:   Fri Sep 4 12:42:26 2026 +0200
+  GIT_TAG ff81ba313ffc5cb27cff5bd6e2edbebf1d65cc29 # Date:   Fri Sep 4 18:44:59 2026 +0200
 )
 list(APPEND FETCH_PACKAGES mqt-core)
 

--- a/mlir/cmake/ExternalDependencies.cmake
+++ b/mlir/cmake/ExternalDependencies.cmake
@@ -4,7 +4,7 @@ set(FETCH_PACKAGES "")
 FetchContent_Declare(
   mqt-core
   GIT_REPOSITORY https://github.com/munich-quantum-toolkit/core.git
-  GIT_TAG 25b7eb8ef50db57abe0de94044821a160f384b89 # Date:   Fri Aug 28 00:41:57 2026 +0200
+  GIT_TAG efbba8902710cebae60e865ef031df146a5868bf # Date:   Fri Sep 4 12:42:26 2026 +0200
 )
 list(APPEND FETCH_PACKAGES mqt-core)
 

--- a/mlir/include/qcc/Constants.h
+++ b/mlir/include/qcc/Constants.h
@@ -16,8 +16,9 @@ namespace qcc {
 /// A unit attribute to mark a `func.func` as *a* starting point of a quantum program.
 static constexpr llvm::StringLiteral entryPointAttrName = "qcc.entry_point";
 
-/// The LLVM dialect attribute whose entries are carried through to the
-/// function's LLVM IR attribute list verbatim.
+/// The LLVM dialect attribute whose entries are carried through to the function's LLVM IR attribute list verbatim. This
+/// is the name under which the attribute lives on an `llvm.func`. On a `func.func` you have to prepend `llvm.` in order
+/// to survive lowering to llvm.
 static constexpr llvm::StringLiteral passthroughAttrName = "passthrough";
 
 /// The `passthrough` entry by which QIR marks a function as *a* entry point.

--- a/mlir/lib/Compiler/Compiler.cpp
+++ b/mlir/lib/Compiler/Compiler.cpp
@@ -51,14 +51,6 @@ static void addLoweringQrisp(mlir::PassManager& pm) {
   // bufferization.
   pm.addPass(mlir::bufferization::createEmptyTensorToAllocTensorPass());
 
-  // Detensorization attempts to convert those rank-0-tensors to plain values
-  // which have not been eliminated in the JaspToQC pass.
-  // Aggressive mode ensures that some trivial `linalg.generic` ops are
-  // unwrapped.
-  mlir::LinalgDetensorizePassOptions detensorizeOptions;
-  detensorizeOptions.aggressiveMode = true;
-  pm.addNestedPass<mlir::func::FuncOp>(mlir::createLinalgDetensorizePass(detensorizeOptions));
-
   // Via Bufferization, we go from value semantics (tensor types) to
   // memory semantics (memref types). We want to make these changes in function signatures
   // as well, and allow for unknown (quantum) operations in the IR.

--- a/mlir/lib/Conversion/ToQIR/ConvertQCToQIR.cpp
+++ b/mlir/lib/Conversion/ToQIR/ConvertQCToQIR.cpp
@@ -437,7 +437,9 @@ private:
         getKV("qir_profiles", "adaptive_profile"), getKV("required_num_qubits", std::to_string(requiredNumQubits)),
         getKV("required_num_results", std::to_string(requiredNumResults))};
 
-    funcOp->setAttr(qcc::passthroughAttrName, builder.getArrayAttr(passthrough));
+    // We set `llvm.passthrough` rather than `passthrough` (`qcc::passthroughAttrName`) because only with the `llvm`
+    // prefix it is forwarded as `passthrough` when lowering to `llvm.func`. Otherwise it is silently dropped.
+    funcOp->setAttr("llvm." + qcc::passthroughAttrName.str(), builder.getArrayAttr(passthrough));
 
     return success();
   }

--- a/mlir/test/tools/qcc-opt/ToQIR/finalize-to-qir.mlir
+++ b/mlir/test/tools/qcc-opt/ToQIR/finalize-to-qir.mlir
@@ -1,6 +1,6 @@
 // RUN: qcc-opt %s -finalize-to-qir | FileCheck %s
 
-func.func @main() -> i64 attributes { qcc.entry_point, passthrough = [ "some_attr" ] } {
+func.func @main() -> i64 attributes { qcc.entry_point, llvm.passthrough = [ "some_attr" ] } {
     %0 = call @get_zero() : () -> i64
     return %0 : i64
 }

--- a/mlir/test/tools/qcc/qrisp-integration/iqpe.mlir
+++ b/mlir/test/tools/qcc/qrisp-integration/iqpe.mlir
@@ -1,6 +1,10 @@
 // RUN: qcc %s -o %t.ll
 // RUN: FileCheck %s --check-prefix=CHECK-QIR < %t.ll
-// RUN: qir-runner --file %t.ll -s 5 | FileCheck %s --check-prefix=CHECK-SIM
+// qir-runner links against an older LLVM that cannot parse the `f0x...` floating-point literal syntax LLVM 23 now emits
+// in textual IR (see https://github.com/llvm/llvm-project/pull/190649), so feed it bitcode instead, which is
+// unaffected. TODO: revert back to text once qir-runner fixes this.
+// RUN: qcc %s -o %t.bc --binary
+// RUN: qir-runner --file %t.bc -s 5 | FileCheck %s --check-prefix=CHECK-SIM
 
 // GENERATED FROM QRISP VERSION 0.9.6
 

--- a/mlir/test/tools/qcc/target-hisepq/control-flow.mlir
+++ b/mlir/test/tools/qcc/target-hisepq/control-flow.mlir
@@ -16,8 +16,7 @@ func.func @main() attributes { qcc.entry_point } {
 // CHECK-LABEL: main:
 // CHECK:           vsetvli    {{.*}}, zero, e8, m1, ta, ma
 // CHECK:           vmv.v.i    [[V1:v[0-9]+]], 1
-// CHECK:           li    [[AVL:a[0-9]+]], 1
-// CHECK:           vsetvli    zero, [[AVL]], e8, m1, ta, ma
+// CHECK:           vsetivli    zero, 1, e8, m1, ta, ma
 // CHECK:           qv.h    [[V1]], zero, 0
 // TODO: qv.mz and bnez are not connected so far. ISA spec says that
 // hardware leaves this unimplemented. Also unclear how to exactly handle the

--- a/mlir/test/tools/qcc/target-hisepq/smoke.mlir
+++ b/mlir/test/tools/qcc/target-hisepq/smoke.mlir
@@ -35,8 +35,7 @@ func.func @main() attributes { qcc.entry_point } {
 // CHECK-DAG:     vmv.s.x  [[V1:v[0-9]+]], zero
 // CHECK-DAG:     vmv.v.i  [[V2:v[0-9]+]], 1
 // CHECK-DAG:     vmv.v.i  [[V3:v[0-9]+]], 2
-// CHECK-DAG:     li       [[AVL:a[0-9]+]], 1
-// CHECK:         vsetvli  zero, [[AVL]], e8, m1, ta, ma
+// CHECK:         vsetivli zero, 1, e8, m1, ta, ma
 // CHECK:         qv.h     [[V1]], zero, 0
 // CHECK:         qv.cx    [[V1]], [[V2]], 0
 // CHECK:         qv.cx    [[V2]], [[V3]], 0

--- a/mlir/tools/qcc-opt/CMakeLists.txt
+++ b/mlir/tools/qcc-opt/CMakeLists.txt
@@ -14,6 +14,10 @@ target_link_libraries(
           MLIRMemRefDialect
           MLIRBufferizationDialect
           MLIRDLTIDialect
+          # `mlir/Conversion/Passes.h` transitively pulls in openmp stuff. GCC at -O0 emits those unused symbols into
+          # object files which then cause unknown symbols errors during linking if we do not add the openmp dialect
+          # library.
+          MLIROpenMPDialect
           QCCJaspDialect
           QCCAuxDialect
           # Passes

--- a/mlir/tools/qcc-opt/qcc-opt.cpp
+++ b/mlir/tools/qcc-opt/qcc-opt.cpp
@@ -78,10 +78,9 @@ int main(int argc, char** argv) {
   mlir::registerConvertLinalgToLoopsPass();
   mlir::bufferization::registerEmptyTensorToAllocTensorPass();
   mlir::bufferization::registerOneShotBufferizePass();
-  mlir::registerLinalgDetensorizePass();
   mlir::bufferization::registerBufferLoopHoistingPass();
   mlir::registerMem2RegPass();
-  mlir::registerSCCP();
+  mlir::registerSCCPPass();
   mlir::bufferization::registerPromoteBuffersToStackPass();
   mlir::registerInlinerPass();
   mlir::affine::registerAffineLoopUnroll();

--- a/third-party/llvm/README.md
+++ b/third-party/llvm/README.md
@@ -24,7 +24,7 @@ cd <repo-root>
 Now build LLVM like so:
 
 ```shell
-cd /path/to/llvm-fork
+cd /path/to/llvm-patched
 
 # Configure. Note that HiSEP-Q is a subtarget of RISCV.
 cmake -G Ninja -S llvm -B build/dev \

--- a/third-party/llvm/base.rev
+++ b/third-party/llvm/base.rev
@@ -1,1 +1,1 @@
-llvmorg-22.1.7
+llvmorg-23.1.0

--- a/third-party/llvm/patches/qisa/0001-Add-HiSEP-Q-Intrinsics-1.patch
+++ b/third-party/llvm/patches/qisa/0001-Add-HiSEP-Q-Intrinsics-1.patch
@@ -1,7 +1,7 @@
-From 24b72a73bda7fcdcd5553782c04bdb9858b3dcd8 Mon Sep 17 00:00:00 2001
+From 5e870f5650f7b9f32187ef03e0266856a4d159c8 Mon Sep 17 00:00:00 2001
 From: Enrique NB <enrique@naranjobejarano.com>
 Date: Tue, 2 Jun 2026 09:28:25 +0200
-Subject: [PATCH 1/2] Add HiSEP-Q Intrinsics (#1)
+Subject: [PATCH 1/4] Add HiSEP-Q Intrinsics (#1)
 
 Added HiSEP-Q (XQV) sub-feature to RISC-V
 
@@ -15,7 +15,7 @@ Co-authored-by: Reinhard Stahn <rainij36@proton.me>
  .../Driver/print-supported-extensions-riscv.c |  1 +
  llvm/include/llvm/IR/IntrinsicsRISCV.td       |  1 +
  llvm/include/llvm/IR/IntrinsicsRISCVXQV.td    | 36 +++++++
- llvm/lib/Target/RISCV/RISCVFeatures.td        |  1 +
+ llvm/lib/Target/RISCV/RISCVFeatures.td        |  2 +
  llvm/lib/Target/RISCV/RISCVFeaturesXQV.td     | 20 ++++
  llvm/lib/Target/RISCV/RISCVInstrFormatsXQV.td | 88 +++++++++++++++++
  llvm/lib/Target/RISCV/RISCVInstrInfo.td       |  1 +
@@ -23,8 +23,8 @@ Co-authored-by: Reinhard Stahn <rainij36@proton.me>
  llvm/test/CodeGen/RISCV/features-info.ll      |  1 +
  llvm/test/CodeGen/RISCV/rv32xqv-bell.ll       | 51 ++++++++++
  llvm/test/MC/RISCV/rv32xqv-valid.s            | 27 ++++++
- .../TargetParser/RISCVISAInfoTest.cpp         |  1 +
- 12 files changed, 324 insertions(+)
+ .../TargetParser/RISCVISAInfoTest.cpp         | 40 +++++---
+ 12 files changed, 350 insertions(+), 14 deletions(-)
  create mode 100644 llvm/include/llvm/IR/IntrinsicsRISCVXQV.td
  create mode 100644 llvm/lib/Target/RISCV/RISCVFeaturesXQV.td
  create mode 100644 llvm/lib/Target/RISCV/RISCVInstrFormatsXQV.td
@@ -33,22 +33,22 @@ Co-authored-by: Reinhard Stahn <rainij36@proton.me>
  create mode 100644 llvm/test/MC/RISCV/rv32xqv-valid.s
 
 diff --git a/clang/test/Driver/print-supported-extensions-riscv.c b/clang/test/Driver/print-supported-extensions-riscv.c
-index 33f3342c66d4..852a2d21ffa9 100644
+index a9af27636781..a3fd8456007d 100644
 --- a/clang/test/Driver/print-supported-extensions-riscv.c
 +++ b/clang/test/Driver/print-supported-extensions-riscv.c
-@@ -249,6 +249,7 @@
- // CHECK-NEXT:     zvqdotq              0.0       'Zvqdotq' (Vector quad widening 4D Dot Product)
+@@ -272,6 +272,7 @@
  // CHECK-NEXT:     smpmpmt              0.6       'Smpmpmt' (PMP-based Memory Types Extension)
  // CHECK-NEXT:     svukte               0.3       'Svukte' (Address-Independent Latency of User-Mode Faults to Supervisor Addresses)
+ // CHECK-NEXT:     xqccmt               0.1       'Xqccmt' (Qualcomm 16-bit Table Jump)
 +// CHECK-NEXT:     xqv                  0.1       'XQV' (QV Quantum Extension (HiSEP-Q 2.0))
- // CHECK-NEXT:     xrivosvisni          0.1       'XRivosVisni' (Rivos Vector Integer Small New)
- // CHECK-NEXT:     xrivosvizip          0.1       'XRivosVizip' (Rivos Vector Register Zips)
  // CHECK-NEXT:     xsfmclic             0.1       'XSfmclic' (SiFive CLIC Machine-mode CSRs)
+ // CHECK-NEXT:     xsfsclic             0.1       'XSfsclic' (SiFive CLIC Supervisor-mode CSRs)
+ // CHECK-EMPTY:
 diff --git a/llvm/include/llvm/IR/IntrinsicsRISCV.td b/llvm/include/llvm/IR/IntrinsicsRISCV.td
-index 9088e5e6a357..a6b9e2421eaa 100644
+index 28cde8111241..2eaf37a18d1e 100644
 --- a/llvm/include/llvm/IR/IntrinsicsRISCV.td
 +++ b/llvm/include/llvm/IR/IntrinsicsRISCV.td
-@@ -1985,3 +1985,4 @@ include "llvm/IR/IntrinsicsRISCVXsf.td"
+@@ -2130,3 +2130,4 @@ include "llvm/IR/IntrinsicsRISCVXsf.td"
  include "llvm/IR/IntrinsicsRISCVXCV.td"
  include "llvm/IR/IntrinsicsRISCVXAndes.td"
  include "llvm/IR/IntrinsicsRISCVXMIPS.td"
@@ -96,13 +96,14 @@ index 000000000000..c1641289f71a
 +    def int_riscv_qv_cx : QVPairIntrinsic;
 +}
 diff --git a/llvm/lib/Target/RISCV/RISCVFeatures.td b/llvm/lib/Target/RISCV/RISCVFeatures.td
-index 494371901e64..296d82fc433e 100644
+index 03d28b8448ba..8c9726fe1519 100644
 --- a/llvm/lib/Target/RISCV/RISCVFeatures.td
 +++ b/llvm/lib/Target/RISCV/RISCVFeatures.td
-@@ -1975,3 +1975,4 @@ def TuneSiFive7 : SubtargetFeature<"sifive7", "RISCVProcFamily", "SiFive7",
+@@ -2195,3 +2195,5 @@ def TuneSiFive7 : SubtargetFeature<"sifive7", "RISCVProcFamily", "SiFive7",
  def TuneVentanaVeyron : SubtargetFeature<"ventana-veyron", "RISCVProcFamily", "VentanaVeyron",
-                                          "Ventana Veyron-Series processors">;
- 
+                                          "Ventana Veyron-Series processors",
+                                          [], InlineIgnore>;
++
 +include "RISCVFeaturesXQV.td"
 diff --git a/llvm/lib/Target/RISCV/RISCVFeaturesXQV.td b/llvm/lib/Target/RISCV/RISCVFeaturesXQV.td
 new file mode 100644
@@ -225,13 +226,13 @@ index 000000000000..84728e1d3023
 +  let Uses = [VL, VTYPE];
 +}
 diff --git a/llvm/lib/Target/RISCV/RISCVInstrInfo.td b/llvm/lib/Target/RISCV/RISCVInstrInfo.td
-index ff582b8e741c..485b860944ef 100644
+index e10ee7389db0..bf0f07800881 100644
 --- a/llvm/lib/Target/RISCV/RISCVInstrInfo.td
 +++ b/llvm/lib/Target/RISCV/RISCVInstrInfo.td
-@@ -2364,6 +2364,7 @@ include "RISCVInstrInfoV.td"
- include "RISCVInstrInfoZvk.td"
- include "RISCVInstrInfoZvqdotq.td"
- include "RISCVInstrInfoZvfofp8min.td"
+@@ -2397,6 +2397,7 @@ include "RISCVInstrInfoZvfofp8min.td"
+ include "RISCVInstrInfoZvzip.td"
+ include "RISCVInstrInfoZvvm.td"
+ include "RISCVInstrInfoZvbdota.td"
 +include "RISCVInstrInfoXQV.td"
  
  // Packed SIMD
@@ -339,17 +340,17 @@ index 000000000000..9a75a381bd50
 +defm : RVPatQVPair<"int_riscv_qv_cx", "PseudoQV_CX">;
 +}
 diff --git a/llvm/test/CodeGen/RISCV/features-info.ll b/llvm/test/CodeGen/RISCV/features-info.ll
-index e327fe73d8a4..c06cb3cf63a0 100644
+index 142e6b269493..255bc2eaa9c0 100644
 --- a/llvm/test/CodeGen/RISCV/features-info.ll
 +++ b/llvm/test/CodeGen/RISCV/features-info.ll
-@@ -30,6 +30,7 @@
- ; CHECK-NEXT:   experimental-rvm23u32            - RISC-V experimental-rvm23u32 profile.
+@@ -27,6 +27,7 @@
  ; CHECK-NEXT:   experimental-smpmpmt             - 'Smpmpmt' (PMP-based Memory Types Extension).
  ; CHECK-NEXT:   experimental-svukte              - 'Svukte' (Address-Independent Latency of User-Mode Faults to Supervisor Addresses).
+ ; CHECK-NEXT:   experimental-xqccmt              - 'Xqccmt' (Qualcomm 16-bit Table Jump).
 +; CHECK-NEXT:   experimental-xqv                 - 'XQV' (QV Quantum Extension (HiSEP-Q 2.0)).
- ; CHECK-NEXT:   experimental-xrivosvisni         - 'XRivosVisni' (Rivos Vector Integer Small New).
- ; CHECK-NEXT:   experimental-xrivosvizip         - 'XRivosVizip' (Rivos Vector Register Zips).
  ; CHECK-NEXT:   experimental-xsfmclic            - 'XSfmclic' (SiFive CLIC Machine-mode CSRs).
+ ; CHECK-NEXT:   experimental-xsfsclic            - 'XSfsclic' (SiFive CLIC Supervisor-mode CSRs).
+ ; CHECK-NEXT:   experimental-y                   - 'Y' ('Base Y' (CHERI)).
 diff --git a/llvm/test/CodeGen/RISCV/rv32xqv-bell.ll b/llvm/test/CodeGen/RISCV/rv32xqv-bell.ll
 new file mode 100644
 index 000000000000..e898bf8fc0e7
@@ -441,17 +442,84 @@ index 000000000000..fc237ae6311e
 +# CHECK-ENCODING: [0x57,0x16,0x94,0x1a]
 +qv.cx v8, v9, 12
 diff --git a/llvm/unittests/TargetParser/RISCVISAInfoTest.cpp b/llvm/unittests/TargetParser/RISCVISAInfoTest.cpp
-index 4439df755d79..656e220c46d7 100644
+index cdc2fcea37fc..d2186c5165fc 100644
 --- a/llvm/unittests/TargetParser/RISCVISAInfoTest.cpp
 +++ b/llvm/unittests/TargetParser/RISCVISAInfoTest.cpp
-@@ -1401,6 +1401,7 @@ Experimental extensions
-     zvqdotq              0.0
+@@ -379,24 +379,35 @@ TEST(ParseArchString, AcceptsSupportedBaseISAsAndSetsXLenAndFLen) {
+   EXPECT_TRUE(ExtsRV64GCV.at("f") == (RISCVISAUtils::ExtensionVersion{2, 2}));
+   EXPECT_TRUE(ExtsRV64GCV.at("d") == (RISCVISAUtils::ExtensionVersion{2, 2}));
+   EXPECT_TRUE(ExtsRV64GCV.at("c") == (RISCVISAUtils::ExtensionVersion{2, 0}));
+-  EXPECT_TRUE(ExtsRV64GCV.at("zicsr") == (RISCVISAUtils::ExtensionVersion{2, 0}));
++  EXPECT_TRUE(ExtsRV64GCV.at("zicsr") ==
++              (RISCVISAUtils::ExtensionVersion{2, 0}));
+   EXPECT_TRUE(ExtsRV64GCV.at("zifencei") ==
+               (RISCVISAUtils::ExtensionVersion{2, 0}));
+-  EXPECT_TRUE(ExtsRV64GCV.at("zmmul") == (RISCVISAUtils::ExtensionVersion{1, 0}));
+-  EXPECT_TRUE(ExtsRV64GCV.at("zaamo") == (RISCVISAUtils::ExtensionVersion{1, 0}));
++  EXPECT_TRUE(ExtsRV64GCV.at("zmmul") ==
++              (RISCVISAUtils::ExtensionVersion{1, 0}));
++  EXPECT_TRUE(ExtsRV64GCV.at("zaamo") ==
++              (RISCVISAUtils::ExtensionVersion{1, 0}));
+   EXPECT_TRUE(ExtsRV64GCV.at("zalrsc") ==
+               (RISCVISAUtils::ExtensionVersion{1, 0}));
+   EXPECT_TRUE(ExtsRV64GCV.at("zca") == (RISCVISAUtils::ExtensionVersion{1, 0}));
+   EXPECT_TRUE(ExtsRV64GCV.at("zcd") == (RISCVISAUtils::ExtensionVersion{1, 0}));
+   EXPECT_TRUE(ExtsRV64GCV.at("v") == (RISCVISAUtils::ExtensionVersion{1, 0}));
+-  EXPECT_TRUE(ExtsRV64GCV.at("zve32x") == (RISCVISAUtils::ExtensionVersion{1, 0}));
+-  EXPECT_TRUE(ExtsRV64GCV.at("zve32f") == (RISCVISAUtils::ExtensionVersion{1, 0}));
+-  EXPECT_TRUE(ExtsRV64GCV.at("zve64x") == (RISCVISAUtils::ExtensionVersion{1, 0}));
+-  EXPECT_TRUE(ExtsRV64GCV.at("zve64f") == (RISCVISAUtils::ExtensionVersion{1, 0}));
+-  EXPECT_TRUE(ExtsRV64GCV.at("zve64d") == (RISCVISAUtils::ExtensionVersion{1, 0}));
+-  EXPECT_TRUE(ExtsRV64GCV.at("zvl32b") == (RISCVISAUtils::ExtensionVersion{1, 0}));
+-  EXPECT_TRUE(ExtsRV64GCV.at("zvl64b") == (RISCVISAUtils::ExtensionVersion{1, 0}));
+-  EXPECT_TRUE(ExtsRV64GCV.at("zvl128b") == (RISCVISAUtils::ExtensionVersion{1, 0}));
++  EXPECT_TRUE(ExtsRV64GCV.at("zve32x") ==
++              (RISCVISAUtils::ExtensionVersion{1, 0}));
++  EXPECT_TRUE(ExtsRV64GCV.at("zve32f") ==
++              (RISCVISAUtils::ExtensionVersion{1, 0}));
++  EXPECT_TRUE(ExtsRV64GCV.at("zve64x") ==
++              (RISCVISAUtils::ExtensionVersion{1, 0}));
++  EXPECT_TRUE(ExtsRV64GCV.at("zve64f") ==
++              (RISCVISAUtils::ExtensionVersion{1, 0}));
++  EXPECT_TRUE(ExtsRV64GCV.at("zve64d") ==
++              (RISCVISAUtils::ExtensionVersion{1, 0}));
++  EXPECT_TRUE(ExtsRV64GCV.at("zvl32b") ==
++              (RISCVISAUtils::ExtensionVersion{1, 0}));
++  EXPECT_TRUE(ExtsRV64GCV.at("zvl64b") ==
++              (RISCVISAUtils::ExtensionVersion{1, 0}));
++  EXPECT_TRUE(ExtsRV64GCV.at("zvl128b") ==
++              (RISCVISAUtils::ExtensionVersion{1, 0}));
+   EXPECT_EQ(InfoRV64GCV.getXLen(), 64U);
+   EXPECT_EQ(InfoRV64GCV.getFLen(), 64U);
+   EXPECT_EQ(InfoRV64GCV.getMinVLen(), 128U);
+@@ -984,7 +995,7 @@ TEST(OrderedExtensionMap, ExtensionsAreCorrectlyOrdered) {
+   // FIXME: 'l' and 'y' should be ordered after 'i', 'm', 'c'.
+   EXPECT_THAT(ExtNames,
+               ElementsAre("i", "m", "l", "c", "y", "zicsr", "zmfoo", "zfinx",
+-                           "zzfoo", "sbar", "sfoo", "xbar", "xfoo"));
++                          "zzfoo", "sbar", "sfoo", "xbar", "xfoo"));
+ }
+ 
+ TEST(ParseArchString, ZceImplication) {
+@@ -1641,6 +1652,7 @@ Experimental extensions
      smpmpmt              0.6
      svukte               0.3
+     xqccmt               0.1
 +    xqv                  0.1
-     xrivosvisni          0.1
-     xrivosvizip          0.1
      xsfmclic             0.1
+     xsfsclic             0.1
+ 
+@@ -1674,8 +1686,8 @@ For example, clang -march=rv32i_v1p0)";
+ 
+   std::string CapturedOutput = testing::internal::GetCapturedStdout();
+   EXPECT_TRUE([](std::string &Captured, std::string &Expected) {
+-                return Captured.find(Expected) != std::string::npos;
+-              }(CapturedOutput, ExpectedOutput));
++    return Captured.find(Expected) != std::string::npos;
++  }(CapturedOutput, ExpectedOutput));
+ }
+ 
+ TEST(TargetParserTest, RISCVPrintEnabledExtensions) {
 -- 
 2.51.1
 

--- a/third-party/llvm/patches/qisa/0002-Update-instruction-encoding-4.patch
+++ b/third-party/llvm/patches/qisa/0002-Update-instruction-encoding-4.patch
@@ -1,7 +1,7 @@
-From 66bc2b5734e400ca50a706fbcda7623a017096b7 Mon Sep 17 00:00:00 2001
+From c83405791e281f9aa1dd8a3c8dd4b2c29e81cf2c Mon Sep 17 00:00:00 2001
 From: Enrique NB <enrique@naranjobejarano.com>
 Date: Thu, 30 Jul 2026 09:05:17 +0200
-Subject: [PATCH 2/2] Update instruction encoding (#4)
+Subject: [PATCH 2/4] Update instruction encoding (#4)
 
 ---
  llvm/lib/Target/RISCV/RISCVInstrFormatsXQV.td | 26 ++++------

--- a/third-party/llvm/patches/qisa/0003-Update-two-qubit-gate-docstring-to-current-naming-co.patch
+++ b/third-party/llvm/patches/qisa/0003-Update-two-qubit-gate-docstring-to-current-naming-co.patch
@@ -1,0 +1,122 @@
+From f1c92117f9e3409c570754c4ac26dc8a4ed6a328 Mon Sep 17 00:00:00 2001
+From: Enrique NB <enrique@naranjobejarano.com>
+Date: Thu, 3 Sep 2026 14:19:01 +0200
+Subject: [PATCH 3/4] Update two-qubit gate docstring to current naming
+ convention (#8)
+
+---
+ llvm/include/llvm/IR/IntrinsicsRISCVXQV.td    |  6 ++---
+ llvm/lib/Target/RISCV/RISCVInstrFormatsXQV.td |  9 +++----
+ llvm/test/CodeGen/RISCV/rv32xqv-bell.ll       | 24 +++++++++----------
+ llvm/test/MC/RISCV/rv32xqv-valid.s            |  2 +-
+ 4 files changed, 21 insertions(+), 20 deletions(-)
+
+diff --git a/llvm/include/llvm/IR/IntrinsicsRISCVXQV.td b/llvm/include/llvm/IR/IntrinsicsRISCVXQV.td
+index c1641289f71a..2324fee0049f 100644
+--- a/llvm/include/llvm/IR/IntrinsicsRISCVXQV.td
++++ b/llvm/include/llvm/IR/IntrinsicsRISCVXQV.td
+@@ -12,7 +12,7 @@
+ 
+ // QV.SINGLE vs1, rs2, Block_imm
+ class QVSingleIntrinsic : Intrinsic<[], // void return type
+-                     [llvm_anyvector_ty, // vs1 (tgt)
++                     [llvm_anyvector_ty, // vs1 (qubits)
+                       llvm_anyint_ty,    // rs2 (tag)
+                       llvm_anyint_ty,    // Block_imm (wait time)
+                       llvm_anyint_ty],   // vl
+@@ -20,8 +20,8 @@ class QVSingleIntrinsic : Intrinsic<[], // void return type
+     
+ // QV.Pair vs1, vs2, Block_imm
+ class QVPairIntrinsic : Intrinsic<[],
+-                     [llvm_anyvector_ty, // vs1 (tgt)
+-                      llvm_anyvector_ty, // vs2 (src)
++                     [llvm_anyvector_ty, // vs1
++                      llvm_anyvector_ty, // vs2
+                       llvm_anyint_ty,    // Block_imm (wait time)
+                       llvm_anyint_ty],   // vl
+                      [IntrHasSideEffects, IntrNoMem]>;
+diff --git a/llvm/lib/Target/RISCV/RISCVInstrFormatsXQV.td b/llvm/lib/Target/RISCV/RISCVInstrFormatsXQV.td
+index 97fbae8f12c1..51babc0c65be 100644
+--- a/llvm/lib/Target/RISCV/RISCVInstrFormatsXQV.td
++++ b/llvm/lib/Target/RISCV/RISCVInstrFormatsXQV.td
+@@ -19,7 +19,7 @@ defvar SupportedQVVTypes = [VI8MF4, VI8MF2, VI8M1, VI8M2, VI8M4, VI8M8];
+ // elem2 channel (e.g., as a software tag or timestamp).
+ // 31       25   24    20   19    15   14  12   11     7   6     0
+ // +---------+----------+----------+--------+----------+---------+
+-// |  GateID |   rs2    |  vs1 (S) | 000(S) | Block_imm| CUSTOM_0|
++// |  GateID |   rs2    |   vs1    | 000(S) | Block_imm| CUSTOM_0|
+ // +---------+----------+----------+--------+----------+---------+
+ 
+ class RVInstQVSingle<bits<7> gateid, string opcodestr>
+@@ -48,11 +48,12 @@ class RVInstQVSingle<bits<7> gateid, string opcodestr>
+ }
+ 
+ // QV.PAIR — Two-Qubit Gate
+-// Applies a two-qubit gate to element-wise pairs from vs2 (source/control)
+-// and vs1 (target).
++// Applies a two-qubit gate to element-wise pairs of the qubits listed
++// in vs1 and vs2. For a controlled gate, vs1 holds the control qubits
++// and vs2 the target qubits.
+ // 31       25   24    20   19    15   14  12   11     7   6     0
+ // +---------+----------+----------+--------+----------+---------+
+-// |  GateID | vs2(src) | vs1(tgt) | 001(P) | Block_imm| CUSTOM_0|
++// |  GateID |   vs2    |    vs1   | 001(P) | Block_imm| CUSTOM_0|
+ // +---------+----------+----------+--------+----------+---------+
+ 
+ class RVInstQVPair<bits<7> gateid, string opcodestr>
+diff --git a/llvm/test/CodeGen/RISCV/rv32xqv-bell.ll b/llvm/test/CodeGen/RISCV/rv32xqv-bell.ll
+index e898bf8fc0e7..e1b6ce6f4fc1 100644
+--- a/llvm/test/CodeGen/RISCV/rv32xqv-bell.ll
++++ b/llvm/test/CodeGen/RISCV/rv32xqv-bell.ll
+@@ -20,8 +20,9 @@ entry:
+   %ctrl = load <vscale x 8 x i8>, ptr @ctrl_qubits, align 8
+   %tgt  = load <vscale x 8 x i8>, ptr @tgt_qubits, align 8
+ 
+-  call void @llvm.riscv.qv.h.nxv8i8.i32.i32.i32(<vscale x 8 x i8> %tgt, i32 85, i32 12, i32 2)
+-  call void @llvm.riscv.qv.cx.nxv8i8.nxv8i8.i32.i32(<vscale x 8 x i8> %tgt, <vscale x 8 x i8> %ctrl, i32 12, i32 4)
++  call void @llvm.riscv.qv.h.nxv8i8.i32.i32.i32(<vscale x 8 x i8> %ctrl, i32 85, i32 12, i32 4)
++  call void @llvm.riscv.qv.cx.nxv8i8.nxv8i8.i32.i32(<vscale x 8 x i8> %ctrl, <vscale x 8 x i8> %tgt, i32 12, i32 4)
++  call void @llvm.riscv.qv.mz.nxv8i8.i32.i32.i32(<vscale x 8 x i8> %ctrl, i32 85, i32 12, i32 4)
+   call void @llvm.riscv.qv.mz.nxv8i8.i32.i32.i32(<vscale x 8 x i8> %tgt, i32 85, i32 12, i32 4)
+ 
+ ; TODO: output recording, e.g. via __quantum__rt__bool_record_output .
+@@ -38,14 +39,13 @@ attributes #0 = { "target-features"="+experimental-xqv" }
+ ; CHECK-NEXT:    addi [[A0]], [[A0]], %lo(ctrl_qubits)
+ ; CHECK-NEXT:    lui [[A1:a[0-9]+]], %hi(tgt_qubits)
+ ; CHECK-NEXT:    addi [[A1]], [[A1]], %lo(tgt_qubits)
+-; CHECK-NEXT:    vl1r.v [[V8:v[0-9]+]], ([[A1]])
+-; CHECK-NEXT:    li [[A1]], 2
+-; CHECK-NEXT:    vl1r.v [[V9:v[0-9]+]], ([[A0]])
+-; CHECK-NEXT:    li [[A0]], 85
+-; CHECK-NEXT:    vsetvli zero, [[A1]], e8, m1, ta, ma
+-; CHECK-NEXT:    qv.h [[V8]], [[A0]], 12
+-; CHECK-NEXT:    li [[A1]], 4
+-; CHECK-NEXT:    vsetvli zero, [[A1]], e8, m1, ta, ma
+-; CHECK-NEXT:    qv.cx [[V8]], [[V9]], 12
+-; CHECK-NEXT:    qv.mz [[V8]], [[A0]], 12
++; CHECK-NEXT:    vl1r.v [[VCTRL:v[0-9]+]], ([[A0]])
++; CHECK-NEXT:    vl1r.v [[VTGT:v[0-9]+]], ([[A1]])
++; CHECK-NEXT:    li [[A0]], 4
++; CHECK-NEXT:    li [[A1]], 85
++; CHECK-NEXT:    vsetvli zero, [[A0]], e8, m1, ta, ma
++; CHECK-NEXT:    qv.h [[VCTRL]], [[A1]], 12
++; CHECK-NEXT:    qv.cx [[VCTRL]], [[VTGT]], 12
++; CHECK-NEXT:    qv.mz [[VCTRL]], [[A1]], 12
++; CHECK-NEXT:    qv.mz [[VTGT]], [[A1]], 12
+ ; CHECK-NEXT:    ret
+diff --git a/llvm/test/MC/RISCV/rv32xqv-valid.s b/llvm/test/MC/RISCV/rv32xqv-valid.s
+index 387bca647f38..3e29388b191c 100644
+--- a/llvm/test/MC/RISCV/rv32xqv-valid.s
++++ b/llvm/test/MC/RISCV/rv32xqv-valid.s
+@@ -26,7 +26,7 @@ qv.x v8, a0, 12
+ # CHECK-ENCODING: [0x0b,0x06,0xa4,0xd0]
+ qv.mz v8, a0, 12
+ 
+-# qv.cx: two-qubit CNOT — qv.cx vs1(tgt), vs2(ctrl), block_imm
++# qv.cx: two-qubit CNOT — qv.cx vs1(ctrl), vs2(tgt), block_imm
+ # gateid=0b1100110, funct3=0b001
+ 
+ # CHECK-INST:     qv.cx v8, v9, 12
+-- 
+2.51.1
+

--- a/third-party/llvm/patches/qisa/0004-Fix-double-re-configuration-issue-9.patch
+++ b/third-party/llvm/patches/qisa/0004-Fix-double-re-configuration-issue-9.patch
@@ -1,0 +1,92 @@
+From c3be8f83012c6c23ec57055654f4809b6e4af9c7 Mon Sep 17 00:00:00 2001
+From: Reinhard Stahn <rainij36@proton.me>
+Date: Thu, 3 Sep 2026 15:24:12 +0200
+Subject: [PATCH 4/4] Fix double re-configuration issue (#9)
+
+In QCC we suffer from double configurations like this (note that the two configurations are identical):
+
+```riscv
+	vsetivli	zero, 8, e8, mf2, ta, ma
+	vid.v	v8
+	li	a0, 8
+	vsetvli	zero, a0, e8, mf2, ta, ma
+	qv.h	v8, zero, 0
+```
+
+After the fix we now emit the much cleaner assembly which uses the immediate format also for the `qv` instructions:
+
+```riscv
+	vsetivli	zero, 8, e8, mf2, ta, ma
+	vid.v	v8
+	qv.h	v8, zero, 0
+```
+---
+ llvm/lib/Target/RISCV/RISCVInstrInfoXQV.td |  6 +++---
+ llvm/test/CodeGen/RISCV/rv32xqv-bell.ll    | 23 +++++++++++-----------
+ 2 files changed, 14 insertions(+), 15 deletions(-)
+
+diff --git a/llvm/lib/Target/RISCV/RISCVInstrInfoXQV.td b/llvm/lib/Target/RISCV/RISCVInstrInfoXQV.td
+index 3cb44a45694c..d7d0cfe08352 100644
+--- a/llvm/lib/Target/RISCV/RISCVInstrInfoXQV.td
++++ b/llvm/lib/Target/RISCV/RISCVInstrInfoXQV.td
+@@ -46,13 +46,13 @@ multiclass RVPseudoQVPair {
+   }
+ }
+ 
+-// Patterns to match the intrinsics to the Pseudos
++// Patterns to match the intrinsics to the Pseudos.
+ multiclass RVPatQVSingle<string intrinsic, string inst> {
+   foreach vti = SupportedQVVTypes in {
+     let Predicates = GetVTypeMinimalPredicates<vti>.Predicates in {
+       def : Pat<(!cast<Intrinsic>(intrinsic) (vti.Vector vti.RegClass:$vs1),
+                                              (XLenVT GPR:$rs2), 
+-                                             (XLenVT uimm5:$block_imm), (XLenVT GPR:$vl)),
++                                             (XLenVT uimm5:$block_imm), VLOpFrag),
+                 (!cast<Instruction>(inst#"_"#vti.LMul.MX) vti.RegClass:$vs1,
+                                                           GPR:$rs2, uimm5:$block_imm,
+                                                           GPR:$vl, vti.Log2SEW)>;
+@@ -64,7 +64,7 @@ multiclass RVPatQVPair<string intrinsic, string inst> {
+   foreach vti = SupportedQVVTypes in {
+     def : Pat<(!cast<Intrinsic>(intrinsic) (vti.Vector vti.RegClass:$vs1),
+                                            (vti.Vector vti.RegClass:$vs2),
+-                                           (XLenVT uimm5:$block_imm), (XLenVT GPR:$vl)),
++                                           (XLenVT uimm5:$block_imm), VLOpFrag),
+               (!cast<Instruction>(inst#"_"#vti.LMul.MX) vti.RegClass:$vs1,
+                                                         vti.RegClass:$vs2,
+                                                         uimm5:$block_imm,
+diff --git a/llvm/test/CodeGen/RISCV/rv32xqv-bell.ll b/llvm/test/CodeGen/RISCV/rv32xqv-bell.ll
+index e1b6ce6f4fc1..2a3abdfe104b 100644
+--- a/llvm/test/CodeGen/RISCV/rv32xqv-bell.ll
++++ b/llvm/test/CodeGen/RISCV/rv32xqv-bell.ll
+@@ -35,17 +35,16 @@ attributes #0 = { "target-features"="+experimental-xqv" }
+ 
+ ; CHECK-LABEL: load_vectors:
+ ; CHECK:       # %bb.0: # %entry
+-; CHECK-NEXT:    lui [[A0:a[0-9]+]], %hi(ctrl_qubits)
+-; CHECK-NEXT:    addi [[A0]], [[A0]], %lo(ctrl_qubits)
+-; CHECK-NEXT:    lui [[A1:a[0-9]+]], %hi(tgt_qubits)
+-; CHECK-NEXT:    addi [[A1]], [[A1]], %lo(tgt_qubits)
+-; CHECK-NEXT:    vl1r.v [[VCTRL:v[0-9]+]], ([[A0]])
+-; CHECK-NEXT:    vl1r.v [[VTGT:v[0-9]+]], ([[A1]])
+-; CHECK-NEXT:    li [[A0]], 4
+-; CHECK-NEXT:    li [[A1]], 85
+-; CHECK-NEXT:    vsetvli zero, [[A0]], e8, m1, ta, ma
+-; CHECK-NEXT:    qv.h [[VCTRL]], [[A1]], 12
++; CHECK-NEXT:    lui [[CTRL:a[0-9]+]], %hi(ctrl_qubits)
++; CHECK-NEXT:    addi [[CTRL]], [[CTRL]], %lo(ctrl_qubits)
++; CHECK-NEXT:    vl1r.v [[VCTRL:v[0-9]+]], ([[CTRL]])
++; CHECK-NEXT:    lui [[TGT:a[0-9]+]], %hi(tgt_qubits)
++; CHECK-NEXT:    addi [[TGT]], [[TGT]], %lo(tgt_qubits)
++; CHECK-NEXT:    vl1r.v [[VTGT:v[0-9]+]], ([[TGT]])
++; CHECK-NEXT:    li [[RS2:a[0-9]+]], 85
++; CHECK-NEXT:    vsetivli zero, 4, e8, m1, ta, ma
++; CHECK-NEXT:    qv.h [[VCTRL]], [[RS2]], 12
+ ; CHECK-NEXT:    qv.cx [[VCTRL]], [[VTGT]], 12
+-; CHECK-NEXT:    qv.mz [[VCTRL]], [[A1]], 12
+-; CHECK-NEXT:    qv.mz [[VTGT]], [[A1]], 12
++; CHECK-NEXT:    qv.mz [[VCTRL]], [[RS2]], 12
++; CHECK-NEXT:    qv.mz [[VTGT]], [[RS2]], 12
+ ; CHECK-NEXT:    ret
+-- 
+2.51.1
+


### PR DESCRIPTION
Resolves #138.

- Bump to llvm version 23.1.0
- Bump to latest MQT Core commit (fitting this llvm version)
- Updated llvm patches accordingly
- Updated default devcontainer accordingly

Update churn:
- Need `llvm.passthrough` (not plain `passthrough`) on `func.func` to lower to llvm and not be discarded.
- `LinalgDetensorizePass` was removed without replacement upstream. I removed it from our pipeline as no tests failed.
- New float syntax `f0x...` breaks `qir-runner`, feeding it bytecode as a workaround.
- riscv assembly: emitted assembly now just better.
- Some upstream passes got renamed.
- Fix link error for gcc -O0 builds (puts openmp stuff in object files)