### PR TITLE
Fix cmake target check-qcc bug

### DIFF
--- a/mlir/test/CMakeLists.txt
+++ b/mlir/test/CMakeLists.txt
@@ -1,20 +1,15 @@
-# For lit config:
-if(QCC_ENABLE_HISEPQ)
-  set(QCC_ENABLE_HISEPQ_PY True)
-else()
-  set(QCC_ENABLE_HISEPQ_PY False)
-endif()
-
 set(MLIR_COMPILER_TEST_DEPENDS FileCheck count not qcc-opt qcc qcc-lsp-server)
 
 if(QCC_ENABLE_HISEPQ)
+  set(QCC_ENABLE_HISEPQ_PY True) # for lit config
   find_program(
     QCC_SIM_HISEPQ_EXECUTABLE
     NAMES sim_hisepq
     HINTS "$ENV{HOME}/.local/bin"
     DOC "Path to the prebuilt HiSEP-Q Verilator testbench (sim_hisepq)")
-
   list(APPEND MLIR_COMPILER_TEST_DEPENDS hisepq-elf2mem)
+else()
+  set(QCC_ENABLE_HISEPQ_PY False)
 endif()
 
 configure_lit_site_cfg(${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py

--- a/mlir/test/CMakeLists.txt
+++ b/mlir/test/CMakeLists.txt
@@ -5,18 +5,20 @@ else()
   set(QCC_ENABLE_HISEPQ_PY False)
 endif()
 
+set(MLIR_COMPILER_TEST_DEPENDS FileCheck count not qcc-opt qcc qcc-lsp-server)
+
 if(QCC_ENABLE_HISEPQ)
   find_program(
     QCC_SIM_HISEPQ_EXECUTABLE
     NAMES sim_hisepq
     HINTS "$ENV{HOME}/.local/bin"
     DOC "Path to the prebuilt HiSEP-Q Verilator testbench (sim_hisepq)")
+
+  list(APPEND MLIR_COMPILER_TEST_DEPENDS hisepq-elf2mem)
 endif()
 
 configure_lit_site_cfg(${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py
                        MAIN_CONFIG ${CMAKE_CURRENT_SOURCE_DIR}/lit.cfg.py)
-
-set(MLIR_COMPILER_TEST_DEPENDS FileCheck count not qcc-opt qcc qcc-lsp-server)
 
 add_lit_testsuite(check-qcc "Run the QCC project tests" ${CMAKE_CURRENT_BINARY_DIR} DEPENDS
                   ${MLIR_COMPILER_TEST_DEPENDS})


### PR DESCRIPTION
Running

```
cmake --preset my-dev
cmake --build build/my-dev --target check-qcc
```

fails on three tests. (One can avoid this by running `cmake --build build/my-dev` in between, which is the reason this did not surface in CI.) The reason for the failure is a missing `hisepq-elf2mem` dependency. This is fixed now.