### PR TITLE
[PoC] Hardware Connectivity Aware Dialect

### DIFF
--- a/mlir/include/qcc/Dialect/CMakeLists.txt
+++ b/mlir/include/qcc/Dialect/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(Aux_) # NOTE: Aux not allowed on windows
 add_subdirectory(Jasp)
+add_subdirectory(QCC)

--- a/mlir/include/qcc/Dialect/QCC/Analysis/ConnectivityAnalysis.h
+++ b/mlir/include/qcc/Dialect/QCC/Analysis/ConnectivityAnalysis.h
@@ -1,0 +1,182 @@
+// ===----------------------------------------------------------------------===//
+//
+// Part of the FullStaQD Project, under the Apache License v2.0 with LLVM
+// Exceptions.
+// See <repo-root>/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// ===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "qcc/Dialect/QCC/IR/QCC.h"
+
+#include "mlir/IR/Dominance.h"
+#include "mlir/IR/Value.h"
+#include "mlir/Support/LLVM.h"
+
+#include <llvm/ADT/ArrayRef.h>
+#include <llvm/ADT/DenseMap.h>
+#include <llvm/ADT/DenseSet.h>
+#include <llvm/ADT/SmallVector.h>
+#include <optional>
+#include <string>
+#include <utility>
+
+namespace qcc::conn {
+
+//===----------------------------------------------------------------------===//
+// Read-only derivations from the IR, in the sense of MLIR's own `lib/Analysis`.
+// Only `DominatingConfigMap` is registered with the pass manager; the other two
+// are constructed directly by the passes that need them.
+//===----------------------------------------------------------------------===//
+
+//===----------------------------------------------------------------------===//
+// Layer 2 — the executable interaction complex
+//===----------------------------------------------------------------------===//
+
+/// `K(P, C)`: the qubit subsets that are actionable right now.
+///
+/// Derived on demand and never stored in the IR. The configuration supplies
+/// co-location and the live links; the device supplies the `link` edges and the
+/// algebraic properties. `control` edges do not contribute.
+///
+/// `K` need not be downward closed, and its facets need not partition the
+/// qubits.
+class InteractionComplex {
+public:
+  InteractionComplex(DeviceAttr device, const Configuration& config);
+
+  /// The representation this complex was built under.
+  [[nodiscard]] Representation getRepresentation() const { return device.getRepresentation(); }
+
+  /// Whether an entangling operation may act on `qubits` right now. The
+  /// argument need not be sorted or deduplicated.
+  ///
+  /// Single-qubit gates are not constrained by `K`; check placement for those.
+  [[nodiscard]] bool isExecutable(llvm::ArrayRef<int64_t> qubits) const;
+
+  /// Why `qubits` is not executable. Undefined if `isExecutable(qubits)` holds.
+  [[nodiscard]] std::string explain(llvm::ArrayRef<int64_t> qubits) const;
+
+  /// A facet together with the widest operation that may act on it. The rank
+  /// is per-facet because addressability is a per-site property.
+  struct Facet {
+    Word qubits;
+    uint64_t rank;
+  };
+
+  /// The maximal executable sets. On a partitioning device these are the groups
+  /// held by sites that can host a gate.
+  [[nodiscard]] llvm::ArrayRef<Facet> getFacets() const { return facets; }
+
+private:
+  /// Index the facets by qubit, when the device declares `partitioning` and the
+  /// derived facets bear that out. Called once the facets are complete.
+  void indexPartition();
+
+  /// Membership by lookup, independent of the number of facets. Available only
+  /// under a verified partition.
+  [[nodiscard]] bool isExecutableInPartition(const Word& wanted) const;
+
+  /// Membership by search over the facets, for a complex whose facets overlap.
+  [[nodiscard]] bool isExecutableByScan(const Word& wanted) const;
+
+  DeviceAttr device;
+  /// Each facet is sorted ascending; the list holds no duplicates.
+  llvm::SmallVector<Facet> facets;
+  /// Qubit to the one facet containing it. Empty unless `partitioned`.
+  llvm::DenseMap<int64_t, unsigned> facetOfQubit;
+  /// Whether the facets were found to partition the qubits they cover.
+  bool partitioned = false;
+  /// Groups held by a site that cannot host an entangling gate. Not facets;
+  /// kept so `explain` can name that case rather than report no facet at all.
+  llvm::SmallVector<std::pair<std::string, Word>> ungated;
+};
+
+//===----------------------------------------------------------------------===//
+// Layer 1 — recovering the configuration at a program point
+//===----------------------------------------------------------------------===//
+
+/// Recovers the configuration behind a `!qcc.config` value by folding its
+/// definition chain: a `qcc.config.init` names one outright, and every rewrite
+/// operation applies its rule to its operand's.
+///
+/// Being a fold rather than a fixpoint, it stops at a block argument, such as a
+/// configuration carried by an `scf.for`. Those are reported as dynamic and the
+/// decision is left to the caller.
+class ConfigurationAnalysis {
+public:
+  struct Result {
+    /// The configuration, when it is statically known.
+    std::optional<Configuration> config;
+    /// The block argument that stopped the fold, when it is not.
+    mlir::Value dynamicOrigin;
+
+    [[nodiscard]] bool isKnown() const { return config.has_value(); }
+  };
+
+  /// Shaped as an MLIR analysis but not obtained through `getAnalysis<>()`: it
+  /// remembers an ill-formed chain after `applyRule` has emitted the diagnostic
+  /// once, so a second pass handed a cached instance would see the failure with
+  /// no diagnostic attached. Registering it requires reworking that first.
+  explicit ConfigurationAnalysis(mlir::Operation* /*root*/) {}
+
+  /// Fold the chain behind `config`, which must have `ConfigType`.
+  ///
+  /// Fails only when a rule in the chain does not apply to the configuration
+  /// reaching it, having already emitted a diagnostic on that operation. A
+  /// well-formed but unknown chain succeeds with an empty `Result::config`.
+  mlir::FailureOr<Result> get(mlir::Value config);
+
+private:
+  llvm::DenseMap<mlir::Value, Result> cache;
+  llvm::DenseSet<mlir::Value> invalid;
+  /// Guards against a malformed chain that reaches itself.
+  llvm::DenseSet<mlir::Value> inFlight;
+};
+
+//===----------------------------------------------------------------------===//
+// Helpers shared with the verification pass
+//===----------------------------------------------------------------------===//
+
+/// The program-level index of a `!qc.qubit` reference, taken from `qc.static`.
+///
+/// A `qc.alloc` qubit and one arriving as an argument both yield `nullopt`,
+/// which callers report as unresolvable rather than as an illegal gate.
+std::optional<int64_t> getQubitIndex(mlir::Value qubit);
+
+/// Resolves the connectivity in force at a program point to the dominating
+/// `!qcc.config` definition, read off the def-use graph.
+///
+/// Registered: obtain it with `getAnalysis<DominatingConfigMap>()`. It emits no
+/// diagnostics and remembers no failures, so caching it across a pipeline is
+/// sound. It owns its `DominanceInfo` rather than borrowing one, which would
+/// dangle whenever a pass preserved this analysis but not that one.
+///
+/// A pass that adds, removes or moves a `!qcc.config` definition must let this
+/// be invalidated, which is the default absent `markAllAnalysesPreserved`.
+class DominatingConfigMap {
+public:
+  explicit DominatingConfigMap(mlir::Operation* function);
+
+  struct Lookup {
+    /// The latest definition dominating the queried operation, if any.
+    mlir::Value config;
+    /// Set when two definitions dominate the operation and neither dominates
+    /// the other, so no single configuration is in force.
+    bool ambiguous = false;
+  };
+
+  [[nodiscard]] Lookup at(mlir::Operation* op);
+
+  /// Whether the function mentions any configuration. One that does not has not
+  /// opted into the dialect and is left unchanged.
+  [[nodiscard]] bool empty() const { return candidates.empty(); }
+
+private:
+  llvm::SmallVector<mlir::Value> candidates;
+  mlir::DominanceInfo dominance;
+};
+
+} // namespace qcc::conn

--- a/mlir/include/qcc/Dialect/QCC/CMakeLists.txt
+++ b/mlir/include/qcc/Dialect/QCC/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_subdirectory(IR)
+add_subdirectory(Transforms)

--- a/mlir/include/qcc/Dialect/QCC/Devices/DeviceLibrary.h
+++ b/mlir/include/qcc/Dialect/QCC/Devices/DeviceLibrary.h
@@ -1,0 +1,145 @@
+// ===----------------------------------------------------------------------===//
+//
+// Part of the FullStaQD Project, under the Apache License v2.0 with LLVM
+// Exceptions.
+// See <repo-root>/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// ===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "qcc/Dialect/QCC/IR/QCC.h"
+
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/Support/LLVM.h"
+
+#include <array>
+#include <cstdint>
+#include <functional>
+#include <llvm/ADT/ArrayRef.h>
+#include <llvm/ADT/SmallVector.h>
+#include <llvm/ADT/StringRef.h>
+#include <optional>
+#include <string>
+
+namespace qcc::conn {
+
+/// The module attribute naming the machine a program is compiled for.
+/// `--qcc-attach-device` writes it; the placement, routing and verification
+/// passes read it.
+constexpr llvm::StringLiteral kDeviceAttrName = "qcc.device";
+
+//===----------------------------------------------------------------------===//
+// Device snapshots
+//===----------------------------------------------------------------------===//
+
+/// One site as a machine description reports it. The fields are those QDMI can
+/// supply, so a hand-written description and an imported one meet here.
+struct SiteSnapshot {
+  std::string name;
+  /// A zone holds many qubits (a trap, a module); a non-zone site holds one (a
+  /// transmon, an SLM trap). QDMI reports this as `ISZONE`.
+  bool isZone = false;
+  /// Transient peak occupancy. QDMI does not report it, so it defaults to 1 and
+  /// must be supplied for a zone.
+  uint64_t capacity = 1;
+  /// Position, when the description gives one.
+  std::optional<std::array<double, 3>> position;
+  /// Module on a modular machine, from QDMI's `MODULEINDEX`.
+  std::optional<uint64_t> moduleIndex;
+};
+
+/// What a machine description reports: sites, the pairs that can interact, and
+/// the arity of the available operations. This is the coupling-graph view, and
+/// for a superconducting chip it is the whole machine.
+struct DeviceSnapshot {
+  std::string name;
+  llvm::SmallVector<SiteSnapshot> sites;
+  /// Pairs of site indices that can interact directly, from QDMI's
+  /// `COUPLINGMAP`.
+  llvm::SmallVector<std::pair<unsigned, unsigned>> couplings;
+  /// Widest single operation, which becomes the device `maxFacetRank`.
+  uint64_t maxOperationArity = 2;
+  /// Rydberg blockade radius, in the units of the site positions. When set,
+  /// blockade discs are derived from geometry rather than listed.
+  std::optional<double> minAtomDistance;
+};
+
+//===----------------------------------------------------------------------===//
+// Device supplements
+//===----------------------------------------------------------------------===//
+
+/// Per-site facts a device-management interface does not report.
+struct SiteOverride {
+  std::string name;
+  std::optional<SiteKind> kind;
+  std::optional<uint64_t> capacity;
+  /// Entangling width. Below 2 means the site cannot host a gate, which is how
+  /// a QCCD description says its storage traps have no gate lasers.
+  std::optional<uint64_t> maxFacetRank;
+  /// Junction turn table and rotation cost.
+  mlir::DictionaryAttr props;
+};
+
+/// The half of a machine description with no coupling-map spelling.
+///
+/// QDMI models a coupling map over qubits that do not move. It has no property
+/// for a transport segment, for the zones sharing a waveform generator, or for
+/// an AOD axis. Those arrive here, and `buildDevice` merges the two halves.
+struct DeviceSupplement {
+  /// Transport segments, control groups, rigid axes, and any link the coupling
+  /// map does not imply.
+  llvm::SmallVector<HyperedgeAttr> edges;
+  llvm::SmallVector<SiteOverride> sites;
+  /// Algebraic properties of `K`. Unset, they are inferred from the snapshot,
+  /// which suits a coupling-graph machine and not one with chains.
+  std::optional<bool> downwardClosed;
+  std::optional<bool> partitioning;
+  std::optional<FacetOrdering> facetOrdering;
+  std::optional<uint64_t> maxFacetRank;
+
+  /// The override for `name`, or nullptr.
+  [[nodiscard]] const SiteOverride* find(llvm::StringRef name) const {
+    for (const auto& site : sites) {
+      if (site.name == name) {
+        return &site;
+      }
+    }
+    return nullptr;
+  }
+};
+
+/// Folds a snapshot and its supplement into the attribute the dialect consumes.
+/// Reports through `emitError` when the two disagree rather than dropping the
+/// part it cannot reconcile.
+mlir::FailureOr<DeviceAttr> buildDevice(mlir::MLIRContext* ctx, const DeviceSnapshot& snapshot,
+                                        const DeviceSupplement& supplement,
+                                        const std::function<mlir::InFlightDiagnostic()>& emitError);
+
+//===----------------------------------------------------------------------===//
+// The library
+//===----------------------------------------------------------------------===//
+
+/// A machine the compiler can describe without being told.
+///
+/// `qcc::Target` selects a backend: how code is emitted. A `DeviceEntry`
+/// selects a machine: where the qubits are and how they move. A program is
+/// compiled for one of each.
+struct DeviceEntry {
+  /// The `--device` value, e.g. "qccd-linear-2".
+  llvm::StringRef name;
+  /// Description shown by `--list-devices`.
+  llvm::StringRef description;
+  /// Builds the description, returning a null attribute on failure.
+  std::function<DeviceAttr(mlir::MLIRContext*)> build;
+};
+
+/// The machines compiled into this build.
+llvm::ArrayRef<DeviceEntry> getDevices();
+
+/// Looks up a machine by its `--device` name, or returns nullptr.
+const DeviceEntry* lookupDevice(llvm::StringRef name);
+
+} // namespace qcc::conn

--- a/mlir/include/qcc/Dialect/QCC/Devices/QDMIImport.h
+++ b/mlir/include/qcc/Dialect/QCC/Devices/QDMIImport.h
@@ -1,0 +1,45 @@
+// ===----------------------------------------------------------------------===//
+//
+// Part of the FullStaQD Project, under the Apache License v2.0 with LLVM
+// Exceptions.
+// See <repo-root>/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// ===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "qcc/Dialect/QCC/Devices/DeviceLibrary.h"
+
+#include "mlir/Support/LLVM.h"
+
+#include <llvm/ADT/StringRef.h>
+
+namespace qcc::conn {
+
+/// Read a machine description out of a QDMI device session.
+///
+/// QDMI reports sites, with `ISZONE`, coordinates, extents and `MODULEINDEX`;
+/// the coupling map; the operation set, whose widest member becomes
+/// `maxFacetRank`; `MINATOMDISTANCE`, from which blockade discs are derived; and
+/// `CHILDDEVICES` for a modular machine. For a superconducting chip that is the
+/// complete description, and the resulting device needs no supplement.
+///
+/// QDMI models a coupling map over qubits that do not move, so it has no
+/// property for a transport segment, for the zones sharing an arbitrary-waveform
+/// generator, for an AOD axis, or for the order of ions in a chain. Those are
+/// supplied by the `DeviceSupplement`, which `buildDevice` merges with the
+/// snapshot.
+///
+/// `queryDeviceSnapshot` is the only part requiring a live session; everything
+/// that interprets the machine description operates on the snapshot and can
+/// therefore be exercised without one.
+///
+/// `session` is a `QDMI_Device_Session`, taken as `void*` so that this header
+/// costs nothing to include when QDMI is not in the build.
+mlir::FailureOr<DeviceSnapshot> queryDeviceSnapshot(void* session);
+
+/// Whether this build was configured with QDMI support.
+bool isQDMIAvailable();
+
+} // namespace qcc::conn

--- a/mlir/include/qcc/Dialect/QCC/IR/CMakeLists.txt
+++ b/mlir/include/qcc/Dialect/QCC/IR/CMakeLists.txt
@@ -1,0 +1,29 @@
+set(LLVM_TARGET_DEFINITIONS QCCEnums.td)
+mlir_tablegen(QCCEnums.h.inc -gen-enum-decls)
+mlir_tablegen(QCCEnums.cpp.inc -gen-enum-defs)
+add_public_tablegen_target(QCCQCCEnumsIncGen)
+
+set(LLVM_TARGET_DEFINITIONS QCCDialect.td)
+mlir_tablegen(QCCDialect.h.inc -gen-dialect-decls -dialect=qcc)
+mlir_tablegen(QCCDialect.cpp.inc -gen-dialect-defs -dialect=qcc)
+add_public_tablegen_target(QCCQCCDialectIncGen)
+
+set(LLVM_TARGET_DEFINITIONS QCCAttributes.td)
+mlir_tablegen(QCCAttributes.h.inc -gen-attrdef-decls -attrdefs-dialect=qcc)
+mlir_tablegen(QCCAttributes.cpp.inc -gen-attrdef-defs -attrdefs-dialect=qcc)
+add_public_tablegen_target(QCCQCCAttributesIncGen)
+
+set(LLVM_TARGET_DEFINITIONS QCCTypes.td)
+mlir_tablegen(QCCTypes.h.inc -gen-typedef-decls -typedefs-dialect=qcc)
+mlir_tablegen(QCCTypes.cpp.inc -gen-typedef-defs -typedefs-dialect=qcc)
+add_public_tablegen_target(QCCQCCTypesIncGen)
+
+set(LLVM_TARGET_DEFINITIONS QCCInterfaces.td)
+mlir_tablegen(QCCInterfaces.h.inc -gen-op-interface-decls)
+mlir_tablegen(QCCInterfaces.cpp.inc -gen-op-interface-defs)
+add_public_tablegen_target(QCCQCCInterfacesIncGen)
+
+set(LLVM_TARGET_DEFINITIONS QCCOps.td)
+mlir_tablegen(QCCOps.h.inc -gen-op-decls)
+mlir_tablegen(QCCOps.cpp.inc -gen-op-defs)
+add_public_tablegen_target(QCCQCCOpsIncGen)

--- a/mlir/include/qcc/Dialect/QCC/IR/Configuration.h
+++ b/mlir/include/qcc/Dialect/QCC/IR/Configuration.h
@@ -1,0 +1,223 @@
+// ===----------------------------------------------------------------------===//
+//
+// Part of the FullStaQD Project, under the Apache License v2.0 with LLVM
+// Exceptions.
+// See <repo-root>/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// ===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+
+#include <cstdint>
+#include <llvm/ADT/ArrayRef.h>
+#include <llvm/ADT/STLExtras.h>
+#include <llvm/ADT/SmallVector.h>
+#include <llvm/ADT/StringRef.h>
+#include <optional>
+#include <string>
+
+namespace qcc::conn {
+
+/// The resource written by every configuration-rewriting operation.
+///
+/// Gates take no configuration operand, so without an effect a rewrite whose
+/// result is unused would be dead code and the motion it describes would be
+/// eliminated.
+struct ConfigurationResource : public mlir::SideEffects::Resource::Base<ConfigurationResource> {
+  llvm::StringRef getName() const final { return "qcc::Configuration"; }
+
+  /// Machine state, not addressable memory, so it never aliases a pointer.
+  bool isAddressable() const final { return false; }
+};
+
+/// How a configuration over a given device is represented.
+///
+/// The device's algebraic properties determine what a configuration can be
+/// without loss of information, and hence how membership in `K` is decided.
+/// The classification is derived from those properties rather than declared,
+/// so a machine description states physics and the model follows from it.
+enum class Representation {
+  /// The rule set is empty, so no operation can produce a new configuration and
+  /// every use resolves to the one `qcc.config.init` established. This is the
+  /// superconducting case, and also any machine that declares no transport,
+  /// rigid or consumable-link edge: with nothing to rewrite, the stronger
+  /// statement applies whatever the other properties say.
+  Static,
+  /// The facets partition the qubits and each group is an ordered word, so the
+  /// interaction complex collapses to an ordered partition with no loss.
+  /// Membership is then a lookup rather than a scan. Trapped ions.
+  OrderedPartition,
+  /// Every site holds at most one qubit, so the placement is an injection and
+  /// the facets are drawn from the substrate rather than from co-location.
+  /// Neutral atoms.
+  Injection,
+  /// The general case: overlapping facets over multi-qubit sites, together with
+  /// the live link multiset, which is consumed by use and is not a function of
+  /// the placement. Modular and photonic machines.
+  ExplicitIncidence,
+};
+
+/// The spelling of `representation`, for diagnostics and `--list-devices`.
+[[nodiscard]] inline llvm::StringRef stringifyRepresentation(const Representation representation) {
+  switch (representation) {
+  case Representation::Static:
+    return "static";
+  case Representation::OrderedPartition:
+    return "ordered-partition";
+  case Representation::Injection:
+    return "injection";
+  case Representation::ExplicitIncidence:
+    return "explicit-incidence";
+  }
+  return "unknown";
+}
+
+/// A group of co-located qubits, as a word over the qubit alphabet. Position 0
+/// is the head. The order is physical state: on a linear target only the ends
+/// of a group may be detached.
+using Word = llvm::SmallVector<int64_t, 8>;
+
+/// The groups a site holds, in spatial order. A site holds several because
+/// splitting a group opens a second potential well without moving anything.
+using SiteContents = llvm::SmallVector<Word, 2>;
+
+/// One site and its contents.
+struct SitePlacement {
+  std::string name;
+  SiteContents groups;
+};
+
+/// What a rewrite rule touches, and therefore what it conflicts over.
+///
+/// The two components answer two different questions and must not be merged.
+/// `sites` carries the double-pushout condition: rules whose matches meet only
+/// inside their interfaces are parallel-independent, so applying them in either
+/// order yields the same configuration. `uses` carries the scheduling
+/// condition: rules contending for one control resource cannot run in the same
+/// time step however disjoint their sites are, but they still commute, because
+/// a control resource is control-plane occupancy rather than a property of the
+/// configuration.
+struct Footprint {
+  llvm::SmallVector<std::string> sites;
+  llvm::SmallVector<std::string> uses;
+
+  /// Whether the two rules may be reordered with respect to one another. This
+  /// is the double-pushout question, and it reads `sites` alone.
+  [[nodiscard]] bool commutesWith(const Footprint& other) const { return !shares(sites, other.sites); }
+
+  /// Whether the two rules may occupy the same time step. Commuting is
+  /// necessary and not sufficient: a shared control resource serialises rules
+  /// that are otherwise independent.
+  [[nodiscard]] bool concurrentWith(const Footprint& other) const {
+    return commutesWith(other) && !shares(uses, other.uses);
+  }
+
+  /// Whether the two rules are held apart by a shared control resource alone,
+  /// that is, whether one more of that resource would let them run together.
+  [[nodiscard]] bool serialisedOnlyByControl(const Footprint& other) const {
+    return commutesWith(other) && shares(uses, other.uses);
+  }
+
+private:
+  static bool shares(llvm::ArrayRef<std::string> lhs, llvm::ArrayRef<std::string> rhs) {
+    return llvm::any_of(lhs, [&](const std::string& name) { return llvm::is_contained(rhs, name); });
+  }
+};
+
+/// The mutable form of a configuration, `C = (pi, <, Lambda)`, which the Layer 3
+/// rules operate on. `PlacementAttr` is the uniqued counterpart of its
+/// placement component.
+///
+/// `links` is what makes a configuration more than a placement. It stays empty
+/// on ion and atom targets. On a photonic target it does not: a heralded Bell
+/// pair is consumed by use, and no placement records whether it is live.
+struct Configuration {
+  /// Sites in the order the placement declared them. A placement need not
+  /// mention every site of the substrate.
+  llvm::SmallVector<SitePlacement> sites;
+
+  /// The live entanglement links, each keeping the party order it was heralded
+  /// with. A multiset: two links over the same parties are two resources.
+  llvm::SmallVector<Word> links;
+
+  /// Index of the site named `name`, if the configuration mentions it.
+  [[nodiscard]] std::optional<unsigned> findSite(llvm::StringRef name) const {
+    for (const auto& [index, site] : llvm::enumerate(sites)) {
+      if (site.name == name) {
+        return static_cast<unsigned>(index);
+      }
+    }
+    return std::nullopt;
+  }
+
+  /// The groups held by site `name`, or nullptr if it is not mentioned.
+  [[nodiscard]] const SiteContents* lookup(llvm::StringRef name) const {
+    const auto index = findSite(name);
+    return index ? &sites[*index].groups : nullptr;
+  }
+  SiteContents* lookup(llvm::StringRef name) {
+    const auto index = findSite(name);
+    return index ? &sites[*index].groups : nullptr;
+  }
+
+  /// Adds `name` if absent and returns its contents.
+  SiteContents& lookupOrAdd(llvm::StringRef name) {
+    if (auto* contents = lookup(name)) {
+      return *contents;
+    }
+    sites.push_back({name.str(), {}});
+    return sites.back().groups;
+  }
+
+  /// Number of qubits held by site `name`, summed over its groups.
+  [[nodiscard]] uint64_t getLoad(llvm::StringRef name) const {
+    const auto* contents = lookup(name);
+    if (contents == nullptr) {
+      return 0;
+    }
+    uint64_t load = 0;
+    for (const auto& group : *contents) {
+      load += group.size();
+    }
+    return load;
+  }
+
+  /// The site holding `qubit`, if it is placed.
+  [[nodiscard]] std::optional<llvm::StringRef> findQubit(int64_t qubit) const {
+    for (const auto& site : sites) {
+      for (const auto& group : site.groups) {
+        if (llvm::is_contained(group, qubit)) {
+          return llvm::StringRef(site.name);
+        }
+      }
+    }
+    return std::nullopt;
+  }
+
+  /// Whether `qubit` is party to a live link.
+  [[nodiscard]] bool isEntangled(int64_t qubit) const {
+    return llvm::any_of(links, [&](const Word& link) { return llvm::is_contained(link, qubit); });
+  }
+
+  /// Position of a live link joining exactly `parties`, in any order. The
+  /// record keeps a party order; matching one for consumption ignores it.
+  [[nodiscard]] std::optional<unsigned> findLink(llvm::ArrayRef<int64_t> parties) const {
+    const auto sorted = [](llvm::ArrayRef<int64_t> qubits) {
+      Word copy(qubits.begin(), qubits.end());
+      llvm::sort(copy);
+      return copy;
+    };
+    const Word wanted = sorted(parties);
+    for (const auto& [index, link] : llvm::enumerate(links)) {
+      if (sorted(link) == wanted) {
+        return static_cast<unsigned>(index);
+      }
+    }
+    return std::nullopt;
+  }
+};
+
+} // namespace qcc::conn

--- a/mlir/include/qcc/Dialect/QCC/IR/QCC.h
+++ b/mlir/include/qcc/Dialect/QCC/IR/QCC.h
@@ -1,0 +1,61 @@
+// ===----------------------------------------------------------------------===//
+//
+// Part of the FullStaQD Project, under the Apache License v2.0 with LLVM
+// Exceptions.
+// See <repo-root>/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// ===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "qcc/Dialect/QCC/IR/Configuration.h" // IWYU pragma: export
+
+#include "mlir/IR/BuiltinAttributeInterfaces.h" // IWYU pragma: keep  (OpAsmAttrInterface)
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/IR/BuiltinTypeInterfaces.h" // IWYU pragma: keep  (OpAsmTypeInterface)
+#include "mlir/IR/DialectImplementation.h"
+#include "mlir/IR/OpDefinition.h"
+#include "mlir/IR/PatternMatch.h"
+#include "mlir/IR/Visitors.h"
+#include "mlir/Interfaces/SideEffectInterfaces.h"
+
+//===----------------------------------------------------------------------===//
+// QCC Enums
+//===----------------------------------------------------------------------===//
+
+#include "qcc/Dialect/QCC/IR/QCCEnums.h.inc"
+
+//===----------------------------------------------------------------------===//
+// QCC Dialect
+//===----------------------------------------------------------------------===//
+
+#include "qcc/Dialect/QCC/IR/QCCDialect.h.inc"
+
+//===----------------------------------------------------------------------===//
+// QCC Attributes
+//===----------------------------------------------------------------------===//
+
+#define GET_ATTRDEF_CLASSES
+#include "qcc/Dialect/QCC/IR/QCCAttributes.h.inc"
+
+//===----------------------------------------------------------------------===//
+// QCC Types
+//===----------------------------------------------------------------------===//
+
+#define GET_TYPEDEF_CLASSES
+#include "qcc/Dialect/QCC/IR/QCCTypes.h.inc"
+
+//===----------------------------------------------------------------------===//
+// QCC Interfaces
+//===----------------------------------------------------------------------===//
+
+#include "qcc/Dialect/QCC/IR/QCCInterfaces.h.inc"
+
+//===----------------------------------------------------------------------===//
+// QCC Operations
+//===----------------------------------------------------------------------===//
+
+#define GET_OP_CLASSES
+#include "qcc/Dialect/QCC/IR/QCCOps.h.inc"

--- a/mlir/include/qcc/Dialect/QCC/IR/QCCAttributes.td
+++ b/mlir/include/qcc/Dialect/QCC/IR/QCCAttributes.td
@@ -1,0 +1,412 @@
+// ===----------------------------------------------------------------------===//
+//
+// Part of the FullStaQD Project, under the Apache License v2.0 with LLVM
+// Exceptions.
+// See <repo-root>/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// ===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_QCC_DIALECT_QCC_IR_QCCATTRIBUTES_TD_
+#define INCLUDE_QCC_DIALECT_QCC_IR_QCCATTRIBUTES_TD_
+
+include "mlir/IR/AttrTypeBase.td"
+include "mlir/IR/BuiltinAttributeInterfaces.td"
+include "mlir/IR/OpAsmInterface.td"
+
+include "qcc/Dialect/QCC/IR/QCCDialect.td"
+include "qcc/Dialect/QCC/IR/QCCEnums.td"
+
+//===----------------------------------------------------------------------===//
+// Parameter helpers
+//===----------------------------------------------------------------------===//
+
+/// A plain `bool` parameter that reads and writes as `true` / `false` rather
+/// than as `1` / `0`, so that a device attribute stays legible.
+def QCC_BoolParam : AttrParameter<"bool", "a boolean flag"> {
+  let parser = [{[&]() -> ::mlir::FailureOr<bool> {
+    if (::mlir::succeeded($_parser.parseOptionalKeyword("true")))
+      return true;
+    if (::mlir::succeeded($_parser.parseOptionalKeyword("false")))
+      return false;
+    return ::mlir::FailureOr<bool>((::llvm::LogicalResult)(
+        $_parser.emitError($_parser.getCurrentLocation())
+        << "expected 'true' or 'false'"));
+  }()}];
+  let printer = [{$_printer << ($_self ? "true" : "false")}];
+}
+
+/// An optional `FacetOrdering`, spelled as a bare keyword. MLIR's stock
+/// `FieldParser` covers optional attributes and optional integers but not
+/// optional enums, so this supplies the two functions the generated format
+/// needs.
+def QCC_OptionalFacetOrdering
+    : AttrParameter<"std::optional<::qcc::conn::FacetOrdering>", "an optional facet ordering"> {
+  let defaultValue = "std::optional<::qcc::conn::FacetOrdering>()";
+  let parser = [{[&]() -> ::mlir::FailureOr<std::optional<::qcc::conn::FacetOrdering>> {
+    const auto loc = $_parser.getCurrentLocation();
+    std::string keyword;
+    if (::mlir::failed($_parser.parseKeywordOrString(&keyword)))
+      return ::mlir::failure();
+    const auto parsed = ::qcc::conn::symbolizeFacetOrdering(keyword);
+    if (!parsed)
+      return ::mlir::FailureOr<std::optional<::qcc::conn::FacetOrdering>>(
+          (::llvm::LogicalResult)($_parser.emitError(loc)
+              << "expected 'none', 'linear' or 'planar'"));
+    return std::optional<::qcc::conn::FacetOrdering>(*parsed);
+  }()}];
+  let printer = [{$_printer << ::qcc::conn::stringifyFacetOrdering(*$_self)}];
+}
+
+//===----------------------------------------------------------------------===//
+// Layer 0 — the static substrate
+//===----------------------------------------------------------------------===//
+
+def QCC_SiteAttr : QCCAttr<"Site", "site"> {
+  let summary = "A node of the substrate hypergraph";
+  let description = [{
+    A place where qubits can be held. `capacity` is the transient maximum rather
+    than the nominal load: during a merge a trap briefly holds every ion it will
+    hold afterwards plus the arriving chain, and a junction must hold a chain in
+    flight. A `fixed` site has capacity 1 and no transport edge may be incident
+    to it, which is what distinguishes a superconducting qubit from a trap.
+
+    `maxFacetRank` gives the width of the widest entangling operation this site
+    can host, overriding the device default. Addressability is a property of the
+    site as well as of the machine: on a QCCD device a storage trap has no gate
+    lasers, so co-location there means only that the ions share a motional mode.
+    A rank below 2 states that no group held at this site contributes a facet,
+    and hence that the qubits must be shuttled elsewhere before they can be
+    acted on. Omitting the field makes the site inherit the device's
+    `maxFacetRank`, which is the appropriate default for a long-chain machine
+    whose trap is also its gate zone.
+
+    `facetOrdering` overrides the device default in the same way, so that one
+    machine may hold linear storage chains alongside an unordered gate zone or a
+    planar crystal. `coords` gives the site a position, which a router uses to
+    prefer a near zone over a far one and from which blockade discs are derived.
+
+    `props` carries the properties only a junction needs. Recognised keys:
+
+    | key                | meaning                                            |
+    |--------------------|----------------------------------------------------|
+    | `turns`            | permitted turns, as `"in>out"` segment-id pairs     |
+    | `turn_latency_us`  | the cost of one rotation                           |
+
+    A junction that declares no `turns` permits every turn. Declaring them
+    restricts which outgoing segment a chain may take given the segment it
+    arrived on, in the manner of a turn-restriction table: the restriction is a
+    property of the node rather than of a ternary edge.
+
+    Example:
+    ```mlir
+    #qcc.site<name = @j0, kind = junction, capacity = 4,
+              props = {turns = ["seg_aj>seg_jb", "seg_jb>seg_aj"],
+                       turn_latency_us = 4.000000e+02}>
+    ```
+
+    Example:
+    ```mlir
+    #qcc.site<name = @storage, kind = trap,     capacity = 30, maxFacetRank = 0>
+    #qcc.site<name = @gate,    kind = gatezone, capacity = 2>
+    ```
+  }];
+
+  let parameters = (ins "::mlir::FlatSymbolRefAttr":$name,
+                        EnumParameter<QCC_SiteKind>:$kind,
+                        "uint64_t":$capacity,
+                        OptionalParameter<"std::optional<uint64_t>">:$maxFacetRank,
+                        QCC_OptionalFacetOrdering:$facetOrdering,
+                        OptionalParameter<"::mlir::DenseF64ArrayAttr">:$coords,
+                        OptionalParameter<"::mlir::DictionaryAttr">:$props);
+
+  // Every field is keyed. Three independently optional tails all beginning with
+  // a comma are not distinguishable by the parser; `struct` resolves this and
+  // prints only the fields that are set.
+  let assemblyFormat = "`<` struct(params) `>`";
+  let genVerifyDecl = 1;
+
+  let extraClassDeclaration = [{
+    /// The bare site name, without the leading `@`.
+    ::llvm::StringRef getSymName() const { return getName().getValue(); }
+    /// How wide an entangling operation this site can host, falling back to the
+    /// device's default when the site does not override it.
+    uint64_t getEffectiveFacetRank(uint64_t deviceDefault) const {
+      return getMaxFacetRank().value_or(deviceDefault);
+    }
+    /// How the qubits in a group held here are arranged, falling back to the
+    /// device default. Overridable per site so that one machine can hold linear
+    /// storage chains alongside an unordered gate zone.
+    FacetOrdering getEffectiveFacetOrdering(FacetOrdering deviceDefault) const {
+      return getFacetOrdering().value_or(deviceDefault);
+    }
+    /// Whether a chain arriving on segment `from` may depart on segment `to`.
+    /// A site that declares no turn table permits every turn.
+    bool permitsTurn(::llvm::StringRef from, ::llvm::StringRef to) const;
+    /// What a rotation costs here, in microseconds. Zero when unstated.
+    double getTurnLatencyUs() const;
+    /// This site's position, when the description gives one.
+    ::std::optional<::std::array<double, 3>> getPosition() const;
+    /// Euclidean distance to `other`, when both sites carry a position. Read by
+    /// the router to prefer a near zone over a far one.
+    ::std::optional<double> distanceTo(SiteAttr other) const;
+  }];
+}
+
+def QCC_HyperedgeAttr : QCCAttr<"Hyperedge", "edge"> {
+  let summary = "A hyperedge of the substrate hypergraph";
+  let description = [{
+    The substrate is a hypergraph rather than a graph. `transport` is rank 2 on
+    QCCD hardware, but the other three relations are not reducible to rank 2:
+    expanding them into cliques loses information. If `{A, B, C, D}` share one
+    AWG, the pairwise-conflict graph is a 4-clique; so is the case where `A-B`
+    share one AWG, `C-D` share another, and the cross pairs conflict for an
+    unrelated reason. The two cases have the same clique and different
+    scheduling semantics.
+
+    `props` carries the device-native metadata. Recognised keys:
+
+    | key               | kind        | meaning                                   |
+    |-------------------|-------------|-------------------------------------------|
+    | `id`              | `transport` | name used by `qcc.ion.transport`'s `via`  |
+    | `latency_us`      | any         | cost in microseconds, read by `getLatency`|
+    | `bidirectional`   | `transport` | traversable in both directions            |
+    | `max_chain_len` | `transport` | longest chain the segment can carry     |
+    | `ends`            | `transport` | which end of each endpoint it meets       |
+    | `persistent`      | `link`      | not consumed by use (a coupler, not a Bell pair) |
+    | `axis`            | `rigid`     | which AOD axis the group travels along    |
+
+    `ends` records the ends of the traps the segment reaches. A trap holds a
+    line of ions and a segment joins it at one end, so only the chain at that
+    end can leave; anything further in would have to pass through the ions in
+    front of it. Give one entry per incident site, in the edge's own order:
+
+    ```mlir
+    #qcc.edge<transport, [@trap_1, @trap_2],
+              {id = "seg", ends = ["head", "tail"], max_chain_len = 1 : i64}>
+    ```
+
+    This declares that the segment meets `@trap_1` at its head and `@trap_2` at
+    its tail. An ion may therefore leave `@trap_1` only from the head and
+    `@trap_2` only from the tail, and an ion arriving at `@trap_2` lands on its
+    tail. Omitting the property treats the segment as reaching either end, which
+    is the appropriate default for a gate zone holding a single chain.
+
+    `id` is required on `transport`, `rigid` and `link` edges, since it is how a
+    rule addresses an edge, and it is unique across the substrate. `persistent`
+    is required on a `link` edge: it determines whether the edge contributes to
+    `K` on its own or only once a link has been generated over it, and has no
+    safe default.
+
+    Example:
+    ```mlir
+    #qcc.edge<transport, [@trap_a, @j0], {id = "seg_aj", latency_us = 8.0e+01}>
+    ```
+  }];
+
+  let parameters = (ins EnumParameter<QCC_EdgeKind>:$kind,
+                        ArrayRefParameter<"::mlir::FlatSymbolRefAttr">:$sites,
+                        "::mlir::DictionaryAttr":$props);
+
+  let assemblyFormat = "`<` $kind `,` `[` $sites `]` `,` $props `>`";
+  let genVerifyDecl = 1;
+
+  let extraClassDeclaration = [{
+    /// The `id` property, or the empty string if absent.
+    ::llvm::StringRef getId() const;
+    /// Which end of `site` this segment meets, when the edge declares its
+    /// doors. Absent means the segment reaches either end.
+    ::std::optional<ChainEnd> getEndAt(::llvm::StringRef site) const;
+    /// Whether a `link` edge is a permanent coupler rather than a resource
+    /// consumed by use. Meaningless on any other kind.
+    bool isPersistent() const;
+    /// The `latency_us` property, or 0.0 if absent.
+    double getLatencyUs() const;
+    /// Whether `key` is present and set to `true`.
+    bool hasFlag(::llvm::StringRef key) const;
+    /// The value of integer property `key`, if present.
+    ::std::optional<int64_t> getIntProp(::llvm::StringRef key) const;
+    /// Whether `site` is one of the incident sites.
+    bool contains(::llvm::StringRef site) const;
+  }];
+}
+
+def QCC_SubstrateAttr : QCCAttr<"Substrate", "substrate", [OpAsmAttrInterface]> {
+  let summary = "The static machine description: a typed hypergraph";
+  let description = [{
+    Layer 0. The substrate is the type graph the configuration is typed over,
+    and is not part of the rewritten object: rules are typed over it rather than
+    carrying it as preserved context. Modelling it as preserved context would
+    make every rewrite rule carry the whole machine description and would admit
+    ill-formed rules that mutate the hardware.
+
+    Example:
+    ```mlir
+    #qcc.substrate<
+      sites = [#qcc.site<name = @trap_a, kind = trap, capacity = 20>,
+               #qcc.site<name = @j0, kind = junction, capacity = 10>],
+      edges = [#qcc.edge<transport, [@trap_a, @j0], {id = "seg_aj"}>]>
+    ```
+  }];
+
+  let parameters = (ins ArrayRefParameter<"::qcc::conn::SiteAttr">:$sites,
+                        ArrayRefParameter<"::qcc::conn::HyperedgeAttr">:$edges);
+
+  // Hand-written: a substrate may legitimately have no edges, as is the case
+  // for a machine of isolated qubits, and the declarative list syntax cannot
+  // parse an empty `[]`.
+  let hasCustomAssemblyFormat = 1;
+  let genVerifyDecl = 1;
+
+  let extraClassDeclaration = [{
+    /// Index of the site named `name`, if it is declared.
+    ::std::optional<unsigned> findSite(::llvm::StringRef name) const;
+    /// The site named `name`, or a null attribute.
+    SiteAttr lookupSite(::llvm::StringRef name) const;
+    /// The edge of kind `kind` whose `id` property is `id`, or a null
+    /// attribute. Ids are unique across the whole substrate, so the kind is a
+    /// statement of what the caller expects to find rather than a disambiguator.
+    HyperedgeAttr lookupEdge(EdgeKind kind, ::llvm::StringRef id) const;
+    /// The transport edge whose `id` property is `id`, or a null attribute.
+    HyperedgeAttr lookupTransportEdge(::llvm::StringRef id) const {
+      return lookupEdge(EdgeKind::Transport, id);
+    }
+    /// All edges of kind `kind`.
+    ::llvm::SmallVector<HyperedgeAttr> getEdgesOfKind(EdgeKind kind) const;
+
+    //===------------------------------------------------------------------===//
+    // OpAsmAttrInterface
+    //===------------------------------------------------------------------===//
+
+    /// A machine description is large and appears on the type of every value in
+    /// a configuration chain. Aliasing it keeps the printed IR focused on what
+    /// varies between operations, namely which rule ran and in what order.
+    ::mlir::OpAsmAliasResult getAlias(::llvm::raw_ostream& os) const {
+      os << "substrate";
+      return ::mlir::OpAsmAliasResult::OverridableAlias;
+    }
+  }];
+}
+
+def QCC_DeviceAttr : QCCAttr<"Device", "device", [OpAsmAttrInterface]> {
+  let summary = "A substrate plus the algebraic properties that select a representation";
+  let description = [{
+    Two booleans and a maximum facet rank characterise the device families the
+    dialect targets. Each affects how `K` must be stored and checked:
+
+    | device                                | rank | downward closed | partitioning | representation     |
+    |---------------------------------------|------|-----------------|--------------|--------------------|
+    | superconducting                       | 2    | yes             | no           | static             |
+    | QCCD gate zone                        | 2    | yes             | yes          | ordered-partition  |
+    | long-chain MS, individual addressing  | k    | yes             | yes          | ordered-partition  |
+    | global MS only                        | k    | **no**          | yes          | ordered-partition  |
+    | neutral-atom Rydberg blockade         | 2..k | yes             | no           | injection          |
+    | modular + photonic links              | 2    | yes             | **no**       | explicit-incidence |
+
+    The representation is derived rather than declared, so the last column
+    follows from the other three together with the substrate; a description
+    states physics and the model follows from it. A machine that declares no
+    transport, rigid or consumable-link edge has an empty rule set whatever else
+    it says, so it is `static` even when its facets would otherwise partition.
+
+    `downwardClosed = false` rules out representing `K` by its facets alone: a
+    machine offering only a global MS gate can act on a whole chain but not on a
+    subset of it, so `{0, 1}` is not executable even though `{0, 1, 2}` is.
+
+    `partitioning = true` asserts the converse for the other axis: the facets of
+    `K` are a partition of the qubits, so a configuration is an ordered
+    partition with no loss of information and membership in `K` is a lookup
+    rather than a search. Together these properties classify the device, which
+    `getRepresentation` reports and `InteractionComplex` acts on.
+
+    Example:
+    ```mlir
+    #qcc.device<substrate = #ion_substrate, maxFacetRank = 10,
+                downwardClosed = true, partitioning = true,
+                facetOrdering = linear>
+    ```
+  }];
+
+  let parameters = (ins "::qcc::conn::SubstrateAttr":$substrate,
+                        "uint64_t":$maxFacetRank,
+                        QCC_BoolParam:$downwardClosed,
+                        QCC_BoolParam:$partitioning,
+                        EnumParameter<QCC_FacetOrdering>:$facetOrdering);
+
+  // `qualified` throughout: the elided short form omits the dialect prefixes
+  // that identify each nested attribute, which a machine description needs.
+  let assemblyFormat = [{
+    `<` `substrate` `=` qualified($substrate) `,`
+        `maxFacetRank` `=` $maxFacetRank `,`
+        `downwardClosed` `=` $downwardClosed `,`
+        `partitioning` `=` $partitioning `,`
+        `facetOrdering` `=` $facetOrdering `>`
+  }];
+  let genVerifyDecl = 1;
+
+  let extraClassDeclaration = [{
+    /// Whether the device admits any rewrite rule. A device with neither a
+    /// transport nor a rigid edge instantiates the empty rule set, so its
+    /// connectivity is static and every `!qcc.config` use resolves to the value
+    /// produced by `qcc.config.init`.
+    bool isStatic() const;
+
+    /// How a configuration over this device is represented, derived from the
+    /// properties above. See `Representation` for what each case means and
+    /// `InteractionComplex` for what it buys.
+    Representation getRepresentation() const;
+
+    //===------------------------------------------------------------------===//
+    // OpAsmAttrInterface
+    //===------------------------------------------------------------------===//
+
+    /// A machine description is large and appears on the type of every value in
+    /// a configuration chain. Aliasing it keeps the printed IR focused on what
+    /// varies between operations, namely which rule ran and in what order.
+    ::mlir::OpAsmAliasResult getAlias(::llvm::raw_ostream& os) const {
+      os << "device";
+      return ::mlir::OpAsmAliasResult::OverridableAlias;
+    }
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// Layer 1 — the configuration snapshot
+//===----------------------------------------------------------------------===//
+
+def QCC_PlacementAttr : QCCAttr<"Placement", "placement"> {
+  let summary = "An ordered partition of the qubits over the sites";
+  let description = [{
+    A frozen Layer 1 configuration. A site holds an ordered list of groups, and
+    a group is a word over the qubit alphabet rather than a set. On an ion
+    machine a group is a chain; splitting one produces a second potential well
+    in the same segment without moving anything, which is why a site holds a
+    list of groups rather than a single word. The order within a group is
+    physical state, since it determines which ions are detachable next, and a
+    set-valued encoding would leave `qcc.ion.split` legality undecidable.
+
+    A placement is a partial injection: a qubit appears at most once, and qubits
+    absent from it are not yet placed.
+
+    Example:
+    ```mlir
+    #qcc.placement<@trap_a = [[0, 1, 2]], @trap_b = [[3], [4, 5]], @j0 = []>
+    ```
+  }];
+
+  let parameters = (ins ArrayRefParameter<"::mlir::FlatSymbolRefAttr">:$sites,
+                        ArrayRefParameter<"::mlir::ArrayAttr">:$groups);
+
+  let hasCustomAssemblyFormat = 1;
+  let genVerifyDecl = 1;
+
+  let extraClassDeclaration = [{
+    /// Materialise the plain, mutable form the rewrite rules operate on.
+    Configuration toConfiguration() const;
+    /// Freeze a plain configuration back into a uniqued attribute.
+    static PlacementAttr get(::mlir::MLIRContext *ctx, const Configuration &config);
+  }];
+  let skipDefaultBuilders = 0;
+}
+
+#endif // INCLUDE_QCC_DIALECT_QCC_IR_QCCATTRIBUTES_TD_

--- a/mlir/include/qcc/Dialect/QCC/IR/QCCDialect.td
+++ b/mlir/include/qcc/Dialect/QCC/IR/QCCDialect.td
@@ -1,0 +1,83 @@
+// ===----------------------------------------------------------------------===//
+//
+// Part of the FullStaQD Project, under the Apache License v2.0 with LLVM
+// Exceptions.
+// See <repo-root>/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// ===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_QCC_DIALECT_QCC_IR_QCCDIALECT_TD_
+#define INCLUDE_QCC_DIALECT_QCC_IR_QCCDIALECT_TD_
+
+include "mlir/IR/AttrTypeBase.td"
+include "mlir/IR/DialectBase.td"
+
+//===----------------------------------------------------------------------===//
+// QCC dialect
+//===----------------------------------------------------------------------===//
+
+def QCCDialect : Dialect {
+    let summary = "Dynamic quantum connectivity as a first-class IR value.";
+    let description = [{
+        Most quantum dialects model connectivity as a fixed coupling graph. On a
+        trapped-ion QCCD machine the compiler moves the qubits, so the subsets
+        it can act on change as it does. The `qcc` dialect represents that
+        change, in four layers:
+
+        | layer | object                                           | spelling                |
+        |-------|--------------------------------------------------|-------------------------|
+        | 0     | substrate: a typed hypergraph of sites and edges  | `#qcc.substrate` (attr) |
+        | 1     | configuration: where the qubits sit               | `!qcc.config` (value)   |
+        | 2     | interaction complex `K(P, C)`: what is executable | derived, never stored   |
+        | 3     | rule set: one double-pushout span per rule        | the operations          |
+
+        Layer 0 is static, hence an attribute, and carries the `transport`,
+        `control`, `rigid` and `link` edges together with the algebraic
+        properties that select a representation. Layer 1 is dynamic, hence an
+        SSA value: an ordered partition, produced by `qcc.config.init` and
+        rewritten by the Layer 3 operations.
+
+        `InteractionComplex` derives Layer 2 from co-location in `C` and the
+        `link` edges of `P`. `transport` and `rigid` edges generate the rule set
+        instead, and `control` edges constrain concurrency rather than
+        connectivity.
+
+        Layer 3 is what differs between machines: `qcc.ion.*` for QCCD,
+        `qcc.atom.*` for neutral atoms, `qcc.link.*` for modular targets. A
+        superconducting device instantiates the empty rule set, and the dialect
+        degenerates to a coupling-graph check.
+
+        Gates are not part of this dialect. They remain in `qc`, and
+        `--qcc-verify-connectivity` checks each against the `K` of its
+        dominating configuration. A function containing no `!qcc.config` is left
+        untouched, so the dialect is opt-in.
+
+        Snapshot semantics follow from the framework: attribute uniquing makes a
+        substrate immutable, and def-use chains make the connectivity in force
+        at a program point the dominating definition. No versioning or
+        invalidation machinery is needed.
+    }];
+
+    let name = "qcc";
+    let cppNamespace = "::qcc::conn";
+
+    let useDefaultAttributePrinterParser = 1;
+    let useDefaultTypePrinterParser = 1;
+}
+
+//===----------------------------------------------------------------------===//
+// Base classes
+//===----------------------------------------------------------------------===//
+
+class QCCAttr<string name, string attrMnemonic, list<Trait> traits = []>
+    : AttrDef<QCCDialect, name, traits> {
+  let mnemonic = attrMnemonic;
+}
+
+class QCCType<string name, string typeMnemonic, list<Trait> traits = []>
+    : TypeDef<QCCDialect, name, traits> {
+  let mnemonic = typeMnemonic;
+}
+
+#endif // INCLUDE_QCC_DIALECT_QCC_IR_QCCDIALECT_TD_

--- a/mlir/include/qcc/Dialect/QCC/IR/QCCEnums.td
+++ b/mlir/include/qcc/Dialect/QCC/IR/QCCEnums.td
@@ -1,0 +1,102 @@
+// ===----------------------------------------------------------------------===//
+//
+// Part of the FullStaQD Project, under the Apache License v2.0 with LLVM
+// Exceptions.
+// See <repo-root>/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// ===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_QCC_DIALECT_QCC_IR_QCCENUMS_TD_
+#define INCLUDE_QCC_DIALECT_QCC_IR_QCCENUMS_TD_
+
+include "mlir/IR/EnumAttr.td"
+
+include "qcc/Dialect/QCC/IR/QCCDialect.td"
+
+//===----------------------------------------------------------------------===//
+// Hyperedge kinds
+//===----------------------------------------------------------------------===//
+
+def QCC_EdgeKind : I32EnumAttr<"EdgeKind", "kind of a substrate hyperedge", [
+    // Displacement of ions or atoms between sites. Always rank 2: displacement
+    // is a binary relation, and a junction is a site of high degree rather than
+    // an edge of high arity.
+    I32EnumAttrCase<"Transport", 0, "transport">,
+    // Sites sharing a control resource such as an AWG, a DAC, a laser path or a
+    // decoder. Rank k, and not reducible to a clique of rank-2 edges, which
+    // would lose which conflict originates from which resource. Constrains
+    // scheduling only; does not contribute to K.
+    I32EnumAttrCase<"Control", 1, "control">,
+    // Sites that move as a unit, such as a neutral-atom AOD row. Rank k.
+    // Contributes to both the rule set and concurrency.
+    I32EnumAttrCase<"Rigid", 2, "rigid">,
+    // An entanglement interconnect (Bell for rank 2, GHZ for rank 3 and above),
+    // or a superconducting coupler when marked `persistent`. Contributes to K.
+    I32EnumAttrCase<"Link", 3, "link">
+  ]> {
+  let cppNamespace = "::qcc::conn";
+}
+
+//===----------------------------------------------------------------------===//
+// Site kinds
+//===----------------------------------------------------------------------===//
+
+def QCC_SiteKind : I32EnumAttr<"SiteKind", "kind of a substrate site", [
+    I32EnumAttrCase<"Trap", 0, "trap">,
+    I32EnumAttrCase<"Junction", 1, "junction">,
+    I32EnumAttrCase<"GateZone", 2, "gatezone">,
+    I32EnumAttrCase<"Module", 3, "module">,
+    // A site that qubits can neither enter nor leave, such as a superconducting
+    // qubit or a neutral-atom SLM trap. Its capacity is 1 and no transport edge
+    // may be incident to it.
+    I32EnumAttrCase<"Fixed", 4, "fixed">
+  ]> {
+  let cppNamespace = "::qcc::conn";
+}
+
+//===----------------------------------------------------------------------===//
+// Facet ordering
+//===----------------------------------------------------------------------===//
+
+def QCC_FacetOrdering : I32EnumAttr<"FacetOrdering",
+    "whether the qubits within a facet carry a physical order", [
+    // Facets are sets: any member may be detached and the order carries no
+    // meaning.
+    I32EnumAttrCase<"None", 0, "none">,
+    // Facets are words: the ions form a linear chain, and a split may only
+    // detach at a chain end. The order is required to decide split legality.
+    I32EnumAttrCase<"Linear", 1, "linear">,
+    // Facets are planar crystals, such as a Penning-trap Coulomb crystal or a
+    // chain past its zigzag transition. The members are jointly addressable and
+    // arranged in two dimensions, so a word cannot describe them.
+    //
+    // Gates on such a site verify against K as they do anywhere else, since K
+    // only queries group membership. The chain rewrite rules, however, are
+    // defined in terms of chain ends, which a plane does not have; they are
+    // rejected on a planar site rather than applied as though the site were
+    // linear. Planar split and merge rules would correspond to operations no
+    // platform currently performs, and can be added alongside the ion rules if
+    // that changes.
+    I32EnumAttrCase<"Planar", 2, "planar">
+  ]> {
+  let cppNamespace = "::qcc::conn";
+}
+
+//===----------------------------------------------------------------------===//
+// Chain ends
+//===----------------------------------------------------------------------===//
+
+def QCC_ChainEnd : I32EnumAttr<"ChainEnd", "an end of an ordered chain", [
+    I32EnumAttrCase<"Head", 0, "head">,
+    I32EnumAttrCase<"Tail", 1, "tail">
+  ]> {
+  let cppNamespace = "::qcc::conn";
+  let genSpecializedAttr = 0;
+}
+
+def QCC_ChainEndAttr : EnumAttr<QCCDialect, QCC_ChainEnd, "chain_end"> {
+  let assemblyFormat = "`<` $value `>`";
+}
+
+#endif // INCLUDE_QCC_DIALECT_QCC_IR_QCCENUMS_TD_

--- a/mlir/include/qcc/Dialect/QCC/IR/QCCInterfaces.td
+++ b/mlir/include/qcc/Dialect/QCC/IR/QCCInterfaces.td
@@ -1,0 +1,101 @@
+// ===----------------------------------------------------------------------===//
+//
+// Part of the FullStaQD Project, under the Apache License v2.0 with LLVM
+// Exceptions.
+// See <repo-root>/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// ===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_QCC_DIALECT_QCC_IR_QCCINTERFACES_TD_
+#define INCLUDE_QCC_DIALECT_QCC_IR_QCCINTERFACES_TD_
+
+include "mlir/IR/OpBase.td"
+
+//===----------------------------------------------------------------------===//
+// TopologyRewriteOpInterface
+//===----------------------------------------------------------------------===//
+
+def QCC_TopologyRewriteOpInterface : OpInterface<"TopologyRewriteOpInterface"> {
+  let description = [{
+    A Layer 3 rule: one double-pushout span `L <- I -> R` over the
+    configuration, expressed as an operation that consumes a `!qcc.config` and
+    produces its successor.
+
+    Implementing this interface is what makes an operation part of a device's
+    rule set. A device with an empty rule set, such as a superconducting chip,
+    has no operation implementing it, so every `!qcc.config` use resolves to the
+    value produced by `qcc.config.init` and the chain carries no dynamics. This
+    is the case in which a static coupling graph is a sufficient model.
+
+    The interface is intentionally small. The QCCD rule set is fixed and short,
+    so each rule is a dedicated operation with its own verifier and cost model
+    rather than an instance of a generic graph-rewrite engine.
+  }];
+
+  let cppNamespace = "::qcc::conn";
+
+  let methods = [
+    InterfaceMethod<
+      "The configuration this rule rewrites — the `L` of the span.",
+      "::mlir::Value", "getInputConfig", (ins), /*methodBody=*/[{}],
+      /*defaultImplementation=*/[{ return $_op.getIn(); }]>,
+
+    InterfaceMethod<
+      "The rewritten configuration — the `R` of the span.",
+      "::mlir::Value", "getOutputConfig", (ins), /*methodBody=*/[{}],
+      /*defaultImplementation=*/[{ return $_op.getOut(); }]>,
+
+    InterfaceMethod<[{
+        Apply the rule to `in`, yielding the successor configuration.
+
+        Returns failure and emits a diagnostic on `$_op` when the rule does not
+        apply — no match for `L`, or a physical precondition such as a site
+        capacity or a chain end is violated. Callers that only want to test
+        applicability should suppress diagnostics around the call.
+      }],
+      "::mlir::FailureOr<::qcc::conn::Configuration>", "applyRule",
+      (ins "const ::qcc::conn::Configuration &":$in)>,
+
+    InterfaceMethod<[{
+        The sites this rule touches and the control resources it contends for.
+
+        Two rules whose sites are disjoint are parallel-independent: their
+        matches meet only inside their interfaces, so applying them in either
+        order yields the same configuration, and they may be reordered.
+
+        Sharing a time step is a strictly stronger condition, and the footprint
+        carries the contended control resources for it. A control resource is
+        control-plane occupancy rather than a property of the configuration, so
+        it constrains concurrency without constraining order; `commutesWith` and
+        `concurrentWith` keep the two questions apart.
+      }],
+      "::qcc::conn::Footprint", "getFootprint", (ins)>,
+
+    InterfaceMethod<
+      "Cost of the rule in device-native units (microseconds).",
+      "double", "getLatencyUs", (ins), /*methodBody=*/[{}],
+      /*defaultImplementation=*/[{ return 0.0; }]>,
+  ];
+
+  let extraSharedClassDeclaration = [{
+    /// Whether this rule and `other` may be reordered with respect to one
+    /// another. This is the double-pushout question and reads only the sites
+    /// the two footprints touch; a shared control resource does not prevent
+    /// reordering, only concurrency.
+    bool commutesWith(TopologyRewriteOpInterface other) {
+      return $_op.getFootprint().commutesWith(other.getFootprint());
+    }
+    /// Whether this rule and `other` may occupy the same time step, which
+    /// additionally requires that they contend for no control resource.
+    bool concurrentWith(TopologyRewriteOpInterface other) {
+      return $_op.getFootprint().concurrentWith(other.getFootprint());
+    }
+    /// The device the rewritten configuration is typed over.
+    ::qcc::conn::DeviceAttr getDeviceAttr() {
+      return ::llvm::cast<::qcc::conn::ConfigType>($_op.getOutputConfig().getType()).getDevice();
+    }
+  }];
+}
+
+#endif // INCLUDE_QCC_DIALECT_QCC_IR_QCCINTERFACES_TD_

--- a/mlir/include/qcc/Dialect/QCC/IR/QCCOps.td
+++ b/mlir/include/qcc/Dialect/QCC/IR/QCCOps.td
@@ -1,0 +1,394 @@
+// ===----------------------------------------------------------------------===//
+//
+// Part of the FullStaQD Project, under the Apache License v2.0 with LLVM
+// Exceptions.
+// See <repo-root>/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// ===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_QCC_DIALECT_QCC_IR_QCCOPS_TD_
+#define INCLUDE_QCC_DIALECT_QCC_IR_QCCOPS_TD_
+
+include "mlir/IR/OpBase.td"
+include "mlir/Interfaces/SideEffectInterfaces.td"
+
+include "qcc/Dialect/QCC/IR/QCCAttributes.td"
+include "qcc/Dialect/QCC/IR/QCCDialect.td"
+include "qcc/Dialect/QCC/IR/QCCInterfaces.td"
+include "qcc/Dialect/QCC/IR/QCCTypes.td"
+
+//===----------------------------------------------------------------------===//
+// Side-effect resource
+//===----------------------------------------------------------------------===//
+
+/// Rewrite operations describe physical motion and must survive dead-code
+/// elimination even when no later operation takes their result as an operand,
+/// which under the dominating-definition discipline gates never do. They
+/// therefore read and write a dedicated resource rather than being `Pure`. The
+/// effect additionally keeps them ordered with respect to one another, which is
+/// what a shuttle schedule requires.
+def QCC_ConfigurationResource : Resource<"::qcc::conn::ConfigurationResource">;
+
+class QCCOp<string mnemonic, list<Trait> traits = []>
+    : Op<QCCDialect, mnemonic, traits>;
+
+/// A Layer 3 rule: consumes one configuration and produces its successor,
+/// keeping the chain live and ordered.
+class QCC_RewriteOp<string mnemonic, list<Trait> traits = []>
+    : QCCOp<mnemonic, !listconcat(traits, [
+        AllTypesMatch<["in", "out"]>,
+        MemoryEffects<[MemRead<QCC_ConfigurationResource>,
+                       MemWrite<QCC_ConfigurationResource>]>,
+        DeclareOpInterfaceMethods<QCC_TopologyRewriteOpInterface, ["applyRule", "getFootprint"]>])> {
+  let results = (outs QCC_ConfigType:$out);
+  let assemblyFormat = "$in attr-dict `:` qualified(type($out))";
+  let hasVerifier = 1;
+}
+
+//===----------------------------------------------------------------------===//
+// Layer 1 — establishing a configuration
+//===----------------------------------------------------------------------===//
+
+def QCC_ConfigInitOp : QCCOp<"config.init", [
+    MemoryEffects<[MemWrite<QCC_ConfigurationResource>]>]> {
+  let summary = "Establish the initial configuration of a machine";
+  let description = [{
+    The root of a configuration chain, and the only operation that states a
+    placement directly. Every downstream configuration is derived from it by
+    applying rules, which lets `ConfigurationAnalysis` be a fold rather than a
+    fixpoint computation.
+
+    The device is carried by the result type rather than repeated here, so a
+    placement is checked against exactly one substrate.
+
+    Example:
+    ```mlir
+    %c0 = qcc.config.init(#qcc.placement<
+        @trap_a = [[0, 1, 2, 3, 4]],
+        @trap_b = [[5, 6, 7, 8, 9]],
+        @j0     = []>) : !qcc.config<#ion>
+    ```
+  }];
+
+  let arguments = (ins QCC_PlacementAttr:$placement);
+  let results = (outs QCC_ConfigType:$out);
+
+  let assemblyFormat = "`(` qualified($placement) `)` attr-dict `:` qualified(type($out))";
+  let hasVerifier = 1;
+
+  let extraClassDeclaration = [{
+    DeviceAttr getDeviceAttr() {
+      return ::llvm::cast<ConfigType>(getOut().getType()).getDevice();
+    }
+  }];
+}
+
+//===----------------------------------------------------------------------===//
+// Layer 3 — the QCCD rule set
+//===----------------------------------------------------------------------===//
+
+def QCC_IonSplitOp : QCC_RewriteOp<"ion.split"> {
+  let summary = "Detach ions from one end of a chain";
+  let description = [{
+    Splits `count` ions off the `end` of chain `chain` at `site`, leaving two
+    chains in the same site. Nothing moves between sites: a split opens a second
+    potential well in the same segment, so the detached part remains in the
+    site's chain list, adjacent to the remainder and on the side it came from.
+
+    Only the ends of a chain can be detached, which is why the operation takes
+    an `end` attribute rather than an arbitrary index. On a device with
+    `facetOrdering = none` a chain has no ends and the operation is rejected.
+
+    Splitting reduces `K`: after detaching ion 0 from `[0 1 2]`, the set
+    `{0, 1}` is no longer executable. A gate requiring it must be ordered before
+    the split; `--qcc-verify-connectivity` reports the violation otherwise.
+
+    Example:
+    ```mlir
+    // @trap_a: [0 1 2 3] -> [0] [1 2 3]
+    %c1 = qcc.ion.split %c0 {site = @trap_a, chain = 0 : i64,
+                             end = #qcc.chain_end<head>, count = 1 : i64}
+        : !qcc.config<#ion>
+    ```
+  }];
+
+  let arguments = (ins QCC_ConfigType:$in,
+                       FlatSymbolRefAttr:$site,
+                       ConfinedAttr<I64Attr, [IntNonNegative]>:$chain,
+                       QCC_ChainEndAttr:$end,
+                       ConfinedAttr<I64Attr, [IntPositive]>:$count);
+}
+
+def QCC_IonMergeOp : QCC_RewriteOp<"ion.merge"> {
+  let summary = "Concatenate two chains held by the same site";
+  let description = [{
+    Merges chain `src` into chain `dst` at `site`, attaching it to the `at`
+    end of `dst`'s word; `src` then leaves the site's chain list.
+
+    The resulting order is physical state. Merging `[0]` onto the head of
+    `[10 11 12]` gives `[0 10 11 12]`, in which ion 0 is detachable without a
+    reorder; merging at the tail gives `[10 11 12 0]`, in which it is not. A
+    set-valued encoding would not distinguish the two.
+
+    Example:
+    ```mlir
+    // @trap_b: [10 11 12] [0] -> [0 10 11 12]
+    %c4 = qcc.ion.merge %c3 {site = @trap_b, dst = 0 : i64, src = 1 : i64,
+                             at = #qcc.chain_end<head>}
+        : !qcc.config<#ion>
+    ```
+  }];
+
+  let arguments = (ins QCC_ConfigType:$in,
+                       FlatSymbolRefAttr:$site,
+                       ConfinedAttr<I64Attr, [IntNonNegative]>:$dst,
+                       ConfinedAttr<I64Attr, [IntNonNegative]>:$src,
+                       QCC_ChainEndAttr:$at);
+}
+
+def QCC_IonTransportOp : QCC_RewriteOp<"ion.transport"> {
+  let summary = "Move a chain across a transport segment";
+  let description = [{
+    Moves chain `chain` out of site `from` and across the transport edge
+    whose `id` property is `via`, appending it to the chain list of the edge's
+    other endpoint.
+
+    Transport edges are rank 2 because displacement is a binary relation: there
+    is no physical operation moving an ion out of `{A, B, C}`. A junction is a
+    site of high degree rather than an edge of high arity, so routing through
+    one is two transports rather than a single ternary step. Routing over such a
+    substrate is therefore an instance of pebble motion on a graph.
+
+    A segment joins a trap at one of its ends. When the edge declares which
+    (`ends = ["head", "tail"]`), only the chain at that end can leave, since a
+    chain further in would have to pass through the ones in front of it. The
+    same property positions arrivals, so an ion entering a trap through its tail
+    end lands on the tail and can leave again by the same route. Omitting `ends`
+    treats the segment as reaching either end, which suits a gate zone holding a
+    single chain.
+
+    The operation is rejected if no such edge exists, if `from` is not one of its
+    endpoints, or if the edge declares `bidirectional = false` and the traversal
+    runs against the declared direction. The end, capacity and `max_chain_len`
+    constraints depend on the configuration and are checked when the rule is
+    applied.
+
+    Example:
+    ```mlir
+    %c2 = qcc.ion.transport %c1 {from = @trap_a, chain = 0 : i64, via = "seg_aj"}
+        : !qcc.config<#ion>
+    ```
+  }];
+
+  let arguments = (ins QCC_ConfigType:$in,
+                       FlatSymbolRefAttr:$from,
+                       ConfinedAttr<I64Attr, [IntNonNegative]>:$chain,
+                       StrAttr:$via);
+
+  let extraClassDeclaration = [{
+    /// The transport edge named by `via`, or a null attribute if the substrate
+    /// does not declare one.
+    HyperedgeAttr getEdge();
+    /// The endpoint the chain arrives at, or the empty string if `getEdge`
+    /// is null or `from` is not an endpoint.
+    ::llvm::StringRef getDestination();
+    /// The `latency_us` property of the traversed segment. The in-place rules
+    /// report the interface default of zero.
+    double getLatencyUs();
+  }];
+}
+
+def QCC_IonJunctionTurnOp : QCC_RewriteOp<"ion.junction_turn"> {
+  let summary = "Rotate a chain at a junction so it can leave on another segment";
+  let description = [{
+    Turns the chain `chain` at junction `site`, which arrived on segment `from`,
+    so that it can depart on segment `to`.
+
+    A turn is a distinct physical action rather than bookkeeping. Carrying a
+    crystal straight through a junction and turning it are different operations:
+    the turn rotates the crystal, costs substantially more than a hop, and on
+    much hardware is possible only between certain pairs of segments. Modelling
+    it as an operation exposes the cost through `getLatencyUs` and the legality
+    through the verifier.
+
+    The permitted turns are a property of the junction, declared as `turns` in
+    the site's `props`, each entry an `"in>out"` pair of segment ids. A junction
+    that declares none permits every turn, which is appropriate for a machine
+    where the rotation is unrestricted.
+
+    Example:
+    ```mlir
+    %c2 = qcc.ion.junction_turn %c1 {site = @j0, chain = 0 : i64,
+                                     from = "seg_aj", to = "seg_jb"}
+        : !qcc.config<#ion>
+    ```
+  }];
+
+  let arguments = (ins QCC_ConfigType:$in,
+                       FlatSymbolRefAttr:$site,
+                       ConfinedAttr<I64Attr, [IntNonNegative]>:$chain,
+                       StrAttr:$from,
+                       StrAttr:$to);
+
+  let extraClassDeclaration = [{
+    /// The junction's `turn_latency_us`. A rotation is slow relative to a hop,
+    /// and is typically the dominant term in a route that crosses a grid.
+    double getLatencyUs();
+  }];
+}
+
+def QCC_IonReorderOp : QCC_RewriteOp<"ion.reorder"> {
+  let summary = "Permute the ions within a chain";
+  let description = [{
+    Rewrites the word of chain `chain` at `site` by `permutation`, where
+    `permutation[i]` is the index in the old word of the ion that ends up at
+    position `i`.
+
+    A reorder leaves `K` unchanged, since the chain holds the same qubits, but
+    it changes which ions are at the ends and therefore which splits are legal
+    next. It is what makes an unfavourable merge recoverable.
+
+    Example:
+    ```mlir
+    // @trap_a: [10 11 0] -> [0 10 11]
+    %c1 = qcc.ion.reorder %c0 {site = @trap_a, chain = 0 : i64,
+                               permutation = array<i64: 2, 0, 1>}
+        : !qcc.config<#ion>
+    ```
+  }];
+
+  let arguments = (ins QCC_ConfigType:$in,
+                       FlatSymbolRefAttr:$site,
+                       ConfinedAttr<I64Attr, [IntNonNegative]>:$chain,
+                       DenseI64ArrayAttr:$permutation);
+}
+
+//===----------------------------------------------------------------------===//
+// Layer 3 — the neutral-atom rule set
+//===----------------------------------------------------------------------===//
+
+def QCC_AtomAodMoveOp : QCC_RewriteOp<"atom.aod_move"> {
+  let summary = "Displace every atom on an AOD axis at once";
+  let description = [{
+    Moves the contents of each site on the rigid edge `via` to the corresponding
+    site in `to`, all in one step.
+
+    A rank-2 transport relation cannot express this rule. One AOD waveform
+    displaces every atom on the axis simultaneously, so the move is a single
+    physical action over k sites rather than k actions over pairs. This is why
+    `rigid` is a hyperedge, and why the binary nature of displacement is a QCCD
+    property rather than a general one. The cost of the move is independent of
+    how many atoms the axis carries.
+
+    The map must be non-crossing. AOD rows cannot pass through one another, so
+    the destinations must appear in the substrate's site order in the same
+    relative order as the sources; the substrate's declaration order is read as
+    the geometric order along the axis.
+
+    Example:
+    ```mlir
+    // every atom in row 0 slides down into row 1
+    %c1 = qcc.atom.aod_move %c0 {via = "aod_row_0", to = [@t10, @t11, @t12]}
+        : !qcc.config<#atoms>
+    ```
+  }];
+
+  let arguments = (ins QCC_ConfigType:$in,
+                       StrAttr:$via,
+                       FlatSymbolRefArrayAttr:$to);
+
+  let extraClassDeclaration = [{
+    /// The rigid edge named by `via`, or a null attribute.
+    HyperedgeAttr getEdge();
+    /// The `latency_us` property of the rigid edge. One waveform drives the
+    /// whole axis, so the cost does not depend on how many atoms it carries.
+    double getLatencyUs();
+  }];
+}
+
+def QCC_AtomSlmTransferOp : QCC_RewriteOp<"atom.slm_transfer"> {
+  let summary = "Hand a single atom from one trap to another";
+  let description = [{
+    Moves the atom held by `from` into `to`: the tweezer handoff that picks one
+    atom out of the static SLM pattern, carries it, and puts it back down. It is
+    the single-atom counterpart of `atom.aod_move`.
+
+    `from` and `to` must share a rigid edge, since the AOD can only carry an
+    atom along an axis the atom is on, so the substrate determines how far a
+    handoff can reach. Rearranging a defective array into a filled one is a
+    sequence of these operations.
+
+    Example:
+    ```mlir
+    %c1 = qcc.atom.slm_transfer %c0 {from = @t00, to = @t02} : !qcc.config<#atoms>
+    ```
+  }];
+
+  let arguments = (ins QCC_ConfigType:$in,
+                       FlatSymbolRefAttr:$from,
+                       FlatSymbolRefAttr:$to);
+}
+
+//===----------------------------------------------------------------------===//
+// Layer 3 — the modular / photonic rule set
+//===----------------------------------------------------------------------===//
+
+def QCC_LinkGenerateOp : QCC_RewriteOp<"link.generate"> {
+  let summary = "Herald an entanglement link between two modules";
+  let description = [{
+    Attempts entanglement over the non-persistent link edge `via` and, on
+    success, adds a live link joining `qubits` to the configuration. Operand `i`
+    of `qubits` is the party in site `i` of the edge, so the operands are given
+    in the edge's own order.
+
+    This rule introduces state a placement alone cannot hold. Elsewhere `K` is a
+    function of where the qubits are; here it is a function of where they are
+    and of which links are currently live. A link exists because this operation
+    ran rather than because two qubits are near one another, and it ceases to
+    exist when it is consumed.
+
+    A qubit holds at most one link at a time, so a party that is already
+    entangled must consume that link before heralding another.
+
+    Example:
+    ```mlir
+    %c1 = qcc.link.generate %c0 {via = "fibre_01", qubits = array<i64: 0, 4>}
+        : !qcc.config<#photonic>
+    ```
+  }];
+
+  let arguments = (ins QCC_ConfigType:$in,
+                       StrAttr:$via,
+                       DenseI64ArrayAttr:$qubits);
+
+  let extraClassDeclaration = [{
+    /// The link edge named by `via`, or a null attribute.
+    HyperedgeAttr getEdge();
+    /// The `latency_us` property of the link edge: the cost of one heralding
+    /// attempt.
+    double getLatencyUs();
+  }];
+}
+
+def QCC_LinkConsumeOp : QCC_RewriteOp<"link.consume"> {
+  let summary = "Spend a live entanglement link";
+  let description = [{
+    Removes one live link joining `qubits`. Teleporting a gate across a link
+    consumes the link, and this operation records that.
+
+    Links are linear resources: the same live link cannot be consumed twice, and
+    once consumed the qubits it joined are no longer a facet of `K` until
+    another link is heralded. A program that entangles across a fibre twice must
+    generate twice, and the verifier reports the omission otherwise.
+
+    Example:
+    ```mlir
+    %c2 = qcc.link.consume %c1 {qubits = array<i64: 0, 4>} : !qcc.config<#photonic>
+    ```
+  }];
+
+  let arguments = (ins QCC_ConfigType:$in, DenseI64ArrayAttr:$qubits);
+}
+
+#endif // INCLUDE_QCC_DIALECT_QCC_IR_QCCOPS_TD_

--- a/mlir/include/qcc/Dialect/QCC/IR/QCCTypes.td
+++ b/mlir/include/qcc/Dialect/QCC/IR/QCCTypes.td
@@ -1,0 +1,70 @@
+// ===----------------------------------------------------------------------===//
+//
+// Part of the FullStaQD Project, under the Apache License v2.0 with LLVM
+// Exceptions.
+// See <repo-root>/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// ===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_QCC_DIALECT_QCC_IR_QCCTYPES_TD_
+#define INCLUDE_QCC_DIALECT_QCC_IR_QCCTYPES_TD_
+
+include "mlir/IR/AttrTypeBase.td"
+include "mlir/IR/OpAsmInterface.td"
+
+include "qcc/Dialect/QCC/IR/QCCAttributes.td"
+include "qcc/Dialect/QCC/IR/QCCDialect.td"
+
+//===----------------------------------------------------------------------===//
+// Configuration type
+//===----------------------------------------------------------------------===//
+
+def QCC_ConfigType : QCCType<"Config", "config", [OpAsmTypeInterface]> {
+  let summary = "The connectivity configuration of a machine at a program point";
+  let description = [{
+    The configuration is threaded through the IR as an SSA value rather than
+    held in a pass-managed side table, which lets existing framework machinery
+    supply what the model needs:
+
+    | requirement           | mechanism                                          |
+    |-----------------------|----------------------------------------------------|
+    | version tracking      | def-use chains; connectivity at a point is the dominating def |
+    | reordering legality   | dependence analysis on the configuration chain     |
+    | snapshot immutability | attribute uniquing                                 |
+    | cost propagation      | `TopologyRewriteOpInterface::getLatencyUs`         |
+
+    The type is parameterised by the device, which is static. The configuration
+    itself is not part of the type; `ConfigurationAnalysis` recovers it from the
+    definition chain, starting at a `qcc.config.init` and folding each rewrite
+    along the way. Two values of the same type therefore describe two different
+    machine states, in the same way that two `!qc.qubit` values describe two
+    different qubits.
+
+    Example:
+    ```mlir
+    %c0 = qcc.config.init(#qcc.placement<@trap_a = [[0, 1]]>) : !qcc.config<#ion>
+    ```
+  }];
+
+  let parameters = (ins "::qcc::conn::DeviceAttr":$device);
+  let assemblyFormat = "`<` qualified($device) `>`";
+
+  let extraClassDeclaration = [{
+    /// The substrate the configuration is typed over.
+    SubstrateAttr getSubstrate() const { return getDevice().getSubstrate(); }
+
+    //===------------------------------------------------------------------===//
+    // OpAsmTypeInterface
+    //===------------------------------------------------------------------===//
+
+    /// Prints as `!config` rather than spelling the full machine description
+    /// inline on every value in the chain. See `DeviceAttr::getAlias`.
+    ::mlir::OpAsmAliasResult getAlias(::llvm::raw_ostream& os) const {
+      os << "config";
+      return ::mlir::OpAsmAliasResult::OverridableAlias;
+    }
+  }];
+}
+
+#endif // INCLUDE_QCC_DIALECT_QCC_IR_QCCTYPES_TD_

--- a/mlir/include/qcc/Dialect/QCC/Transforms/CMakeLists.txt
+++ b/mlir/include/qcc/Dialect/QCC/Transforms/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(LLVM_TARGET_DEFINITIONS Passes.td)
+mlir_tablegen(Passes.h.inc -gen-pass-decls -name QCCTransforms)
+add_public_tablegen_target(QCCQCCTransformsIncGen)
+
+add_mlir_doc(Passes QCCTransforms Dialects/ -gen-pass-doc)

--- a/mlir/include/qcc/Dialect/QCC/Transforms/Passes.h
+++ b/mlir/include/qcc/Dialect/QCC/Transforms/Passes.h
@@ -1,0 +1,24 @@
+// ===----------------------------------------------------------------------===//
+//
+// Part of the FullStaQD Project, under the Apache License v2.0 with LLVM
+// Exceptions.
+// See <repo-root>/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// ===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "qcc/Dialect/QCC/IR/QCC.h" // IWYU pragma: keep
+
+#include "mlir/Dialect/Func/IR/FuncOps.h" // IWYU pragma: keep
+
+#include <mlir/Pass/Pass.h>
+
+namespace qcc {
+#define GEN_PASS_DECL
+#include "qcc/Dialect/QCC/Transforms/Passes.h.inc"
+
+#define GEN_PASS_REGISTRATION
+#include "qcc/Dialect/QCC/Transforms/Passes.h.inc"
+} // namespace qcc

--- a/mlir/include/qcc/Dialect/QCC/Transforms/Passes.td
+++ b/mlir/include/qcc/Dialect/QCC/Transforms/Passes.td
@@ -1,0 +1,223 @@
+// ===----------------------------------------------------------------------===//
+//
+// Part of the FullStaQD Project, under the Apache License v2.0 with LLVM
+// Exceptions.
+// See <repo-root>/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// ===----------------------------------------------------------------------===//
+
+#ifndef INCLUDE_QCC_DIALECT_QCC_TRANSFORMS_PASSES_TD_
+#define INCLUDE_QCC_DIALECT_QCC_TRANSFORMS_PASSES_TD_
+
+include "mlir/Pass/PassBase.td"
+
+def VerifyConnectivity : Pass<"qcc-verify-connectivity", "::mlir::func::FuncOp"> {
+  let summary = "Check every gate against the connectivity in force where it stands.";
+  let description = [{
+    This pass is the interface between the `qcc` and `qc` dialects. Gates are
+    left unchanged: they remain `qc` operations acting on `!qc.qubit`
+    references and take no configuration operand. For each gate, the pass:
+
+    1. resolves its qubits to program indices (`qc.static`);
+    2. finds the `!qcc.config` definition that dominates it, which is the
+       dialect's notion of connectivity at a program point;
+    3. folds that definition's chain back to a `qcc.config.init` to recover the
+       configuration, and derives `K` from it;
+    4. checks the gate's qubit set against `K`.
+
+    Multi-qubit gates must be a face of a facet (or, on a device that is not
+    downward closed, a facet exactly). Single-qubit gates are checked only for
+    being placed at all, since local rotations do not depend on co-location.
+
+    A `qc.call` implements the same unitary interface and is checked as the
+    joint set of the qubits it passes. This is conservative, since a callee that
+    decomposes internally into pairwise interactions does not require all of its
+    qubits in one facet. Checking the callee body instead is not possible: it is
+    a separate `func.func` whose qubits arrive as block arguments carrying no
+    program index, so skipping the call site would leave it unverified.
+
+    A function containing no `!qcc.config` is skipped entirely, so adding this
+    pass to a pipeline cannot break a program that does not opt in.
+
+    Because gates carry no operand edge to the configuration, nothing in the IR
+    prevents a later pass from sinking a gate across a `qcc.ion.split` that
+    invalidates it. The intended discipline is to re-run this pass after any
+    reordering; expressing the dependence explicitly would require adding a
+    configuration operand to every gate in the `qc` dialect.
+
+    Loop-carried configurations are reported rather than checked; see
+    `allow-dynamic`.
+  }];
+
+  let options = [
+    Option<"allowDynamic", "allow-dynamic", "bool", /*default=*/"false",
+           "Emit a warning instead of an error for gates whose configuration is "
+           "not statically known. A shuttle inside an `scf.for` makes the "
+           "configuration a loop-carried block argument, and unless the body's "
+           "net rewrite is the identity, no single placement describes that "
+           "program point. Deciding this requires abstract interpretation over "
+           "an ordered-partition lattice, which the pass does not implement, so "
+           "such gates are rejected by default.">,
+    Option<"requireResolvableQubits", "require-resolvable-qubits", "bool",
+           /*default=*/"true",
+           "Treat a gate whose qubits carry no program index as an error. Set "
+           "to false to skip such gates instead, which is useful before "
+           "dynamically allocated qubits have been rewritten to `qc.static`.">,
+  ];
+
+  let dependentDialects = [
+    "::mlir::func::FuncDialect",
+    "::mlir::qc::QCDialect",
+    "::qcc::conn::QCCDialect",
+  ];
+}
+
+//===----------------------------------------------------------------------===//
+// Workflow 1 — fit a hardware-agnostic program to a machine
+//===----------------------------------------------------------------------===//
+
+def AttachDevice : Pass<"qcc-attach-device", "::mlir::ModuleOp"> {
+  let summary = "Record which machine a program is being compiled for.";
+  let description = [{
+    Attaches a `qcc.device` attribute to the module, naming the machine that
+    every later pass checks and rewrites against. It is the step that gives a
+    hardware-agnostic program a target, and the only place a machine description
+    enters the pipeline.
+
+    A description has two possible sources, which compose. `device=<name>`
+    selects one of the machines compiled into this build, as enumerated by
+    `--list-devices`. A description read from QDMI supplies the coupling-graph
+    part, namely sites, couplings, operation arities and blockade radius, and a
+    supplement adds the transport, control and rigid edges that a device
+    management interface does not describe.
+
+    This option is orthogonal to `--target`: `--target` selects a backend, that
+    is, how code is emitted, while `--device` selects a machine, that is, where
+    the qubits are and how they move.
+  }];
+
+  let options = [
+    Option<"device", "device", "std::string", /*default=*/"\"\"",
+           "Name of a machine compiled into this build, as listed by "
+           "`--list-devices`.">,
+  ];
+
+  let dependentDialects = ["::qcc::conn::QCCDialect"];
+}
+
+def PlaceQubits : Pass<"qcc-place-qubits", "::mlir::func::FuncOp"> {
+  let summary = "Choose where each qubit starts out on the attached machine.";
+  let description = [{
+    Emits the `qcc.config.init` that the rest of the dialect reads, assigning
+    every qubit the function mentions to a site of the machine on the module's
+    `qcc.device` attribute. A function that already establishes a configuration
+    is left alone, so a hardware-aware program passes through untouched.
+
+    The placement strategy is the simplest correct one: qubits are laid into
+    sites in declaration order, filling each to capacity before moving on. It
+    respects capacity and never places a qubit twice, so its output always
+    verifies. It does not consider which qubits the program interacts, so on a
+    machine with a non-empty rule set it leaves the router more work than a
+    placement heuristic would.
+
+    A better strategy reads the gate graph and co-locates qubits that interact.
+    Such a heuristic replaces the body of this pass and nothing else, since
+    everything downstream consumes the emitted `qcc.config.init`.
+  }];
+
+  let dependentDialects = ["::qcc::conn::QCCDialect", "::mlir::qc::QCDialect"];
+}
+
+def Route : Pass<"qcc-route", "::mlir::func::FuncOp"> {
+  let summary = "Report which gates the current configuration cannot execute.";
+  let description = [{
+    Walks the gates in program order against the configuration in force at each
+    one and reports every gate whose operands are not a facet of `K`, along with
+    where those qubits currently sit.
+
+    The pass does not insert shuttles. Finding a sequence that brings the
+    operands together is pebble motion on a graph with capacities and chain
+    order; the pass instead reports precisely what is unreachable, in the order
+    a router would have to address it.
+
+    `emit-remarks` reports as remarks rather than errors, so that a pipeline
+    runs to completion and the whole work list is visible at once.
+  }];
+
+  let options = [
+    Option<"emitRemarks", "emit-remarks", "bool", /*default=*/"false",
+           "Report unroutable gates as remarks rather than errors, so that a "
+           "pipeline continues and the whole work list is visible at once.">,
+  ];
+
+  let dependentDialects = ["::qcc::conn::QCCDialect", "::mlir::qc::QCDialect"];
+}
+
+//===----------------------------------------------------------------------===//
+// Workflow 2 — check and improve a hardware-aware program
+//===----------------------------------------------------------------------===//
+
+def OptimizeShuttling : Pass<"qcc-optimize-shuttling", "::mlir::func::FuncOp"> {
+  let summary = "Remove shuttling work that the program does not need.";
+  let description = [{
+    Operates on a program that already carries its own configuration chain and
+    shortens that chain without changing the configuration any gate observes.
+
+    The transformation applied is removal of a maximal suffix of rewrite
+    operations that no observer reads. A hand-written schedule routinely ends by
+    returning ions to where they started; when nothing is executed afterwards,
+    that motion costs machine time for no observable effect.
+
+    The pass does not reorder. Two shuttles commute only when their
+    double-pushout footprints are disjoint and no control edge serialises them,
+    which is what `--qcc-schedule-concurrency` computes; reordering is left to
+    that pass.
+
+    Total latency saved, taken from `TopologyRewriteOpInterface::getLatencyUs`,
+    is reported as a remark, so the effect is visible without diffing the IR.
+  }];
+
+  let dependentDialects = ["::qcc::conn::QCCDialect", "::mlir::qc::QCDialect"];
+}
+
+def ScheduleConcurrency : Pass<"qcc-schedule-concurrency", "::mlir::func::FuncOp"> {
+  let summary = "Work out which rewrites can run at the same time.";
+  let description = [{
+    Packs the rewrite operations of a function into time steps and annotates
+    each with the step it lands in, so a backend can emit them as a schedule
+    rather than a sequence.
+
+    Two independent constraints decide the packing:
+
+    - Configuration dependence. Two rules may share a step only if their
+      double-pushout footprints are disjoint. When the sites they touch do not
+      overlap, applying them in either order yields the same configuration.
+    - Control contention. Two rules may share a step only if they contend for no
+      `control` hyperedge. A single arbitrary-waveform generator driving every
+      shuttling electrode serialises transports on segments that are otherwise
+      unrelated, which no reasoning about placement can discover.
+
+    This is the only pass that derives anything from `control` edges. They never
+    contribute to `K`, so connectivity checking ignores them; scheduling is the
+    analysis they exist for.
+
+    The SSA chain is not consulted. Threading a single configuration value
+    through every rule totally orders them in the IR, but that order is a
+    property of the representation rather than of the machine; the footprints
+    are what bind.
+
+    The remark reports how many pairs were serialised only by a shared control
+    resource, which is the number of pairs an additional control resource would
+    allow to run concurrently.
+  }];
+
+  let options = [
+    Option<"annotate", "annotate", "bool", /*default=*/"true",
+           "Record each rewrite's time step as a `qcc.step` attribute.">,
+  ];
+
+  let dependentDialects = ["::qcc::conn::QCCDialect"];
+}
+
+#endif // INCLUDE_QCC_DIALECT_QCC_TRANSFORMS_PASSES_TD_

--- a/mlir/lib/Dialect/CMakeLists.txt
+++ b/mlir/lib/Dialect/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(Aux_) # NOTE: Aux not allowed on windows
 add_subdirectory(Jasp)
+add_subdirectory(QCC)

--- a/mlir/lib/Dialect/QCC/Analysis/CMakeLists.txt
+++ b/mlir/lib/Dialect/QCC/Analysis/CMakeLists.txt
@@ -1,0 +1,18 @@
+add_mlir_library(
+  QCCQCCAnalysis
+  ConnectivityAnalysis.cpp
+  DEPENDS
+  QCCQCCEnumsIncGen
+  QCCQCCDialectIncGen
+  QCCQCCAttributesIncGen
+  QCCQCCTypesIncGen
+  QCCQCCInterfacesIncGen
+  QCCQCCOpsIncGen
+  LINK_LIBS
+  PUBLIC
+  QCCQCCDialect
+  MLIRIR
+  MLIRSupport
+  MLIRQCDialect)
+
+mqt_mlir_target_use_project_options(QCCQCCAnalysis)

--- a/mlir/lib/Dialect/QCC/Analysis/ConnectivityAnalysis.cpp
+++ b/mlir/lib/Dialect/QCC/Analysis/ConnectivityAnalysis.cpp
@@ -1,0 +1,404 @@
+// ===----------------------------------------------------------------------===//
+//
+// Part of the FullStaQD Project, under the Apache License v2.0 with LLVM
+// Exceptions.
+// See <repo-root>/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// ===----------------------------------------------------------------------===//
+
+#include "qcc/Dialect/QCC/Analysis/ConnectivityAnalysis.h"
+
+#include "qcc/Dialect/QCC/IR/QCC.h"
+
+#include "mlir/Dialect/QC/IR/QCDialect.h"
+#include "mlir/Dialect/QC/IR/QCOps.h"
+#include "mlir/IR/Dominance.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/IR/Value.h"
+#include "mlir/Support/LLVM.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <llvm/ADT/ArrayRef.h>
+#include <llvm/ADT/STLExtras.h>
+#include <llvm/ADT/ScopeExit.h>
+#include <llvm/ADT/SmallVector.h>
+#include <llvm/Support/Casting.h>
+#include <llvm/Support/raw_ostream.h>
+#include <optional>
+#include <string>
+#include <utility>
+
+using namespace mlir;
+
+namespace qcc::conn {
+
+//===----------------------------------------------------------------------===//
+// InteractionComplex
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+/// Sorted, deduplicated copy of `qubits`.
+Word normalize(const llvm::ArrayRef<int64_t> qubits) {
+  Word sorted(qubits.begin(), qubits.end());
+  llvm::sort(sorted);
+  sorted.erase(std::unique(sorted.begin(), sorted.end()), sorted.end());
+  return sorted;
+}
+
+/// Both arguments must be sorted ascending.
+bool isSubset(const llvm::ArrayRef<int64_t> subset, const llvm::ArrayRef<int64_t> superset) {
+  return std::includes(superset.begin(), superset.end(), subset.begin(), subset.end());
+}
+
+void printSet(llvm::raw_ostream& os, const llvm::ArrayRef<int64_t> qubits) {
+  os << "{";
+  llvm::interleaveComma(qubits, os);
+  os << "}";
+}
+
+} // namespace
+
+InteractionComplex::InteractionComplex(const DeviceAttr device, const Configuration& config) : device(device) {
+  const auto add = [&](Word qubits, const uint64_t rank) {
+    llvm::sort(qubits);
+    qubits.erase(std::unique(qubits.begin(), qubits.end()), qubits.end());
+    if (qubits.size() < 2) {
+      return;
+    }
+    // The same qubits may be a facet by more than one route; the widest rank
+    // among them is the one that applies.
+    for (auto& existing : facets) {
+      if (existing.qubits == qubits) {
+        existing.rank = std::max(existing.rank, rank);
+        return;
+      }
+    }
+    facets.push_back({std::move(qubits), rank});
+  };
+
+  const auto substrate = device.getSubstrate();
+  const auto deviceRank = device.getMaxFacetRank();
+
+  // Co-location is the first source of facets: the ions of one group share a
+  // motional mode and can be addressed together, but only at a site the machine
+  // can address. A storage trap on a QCCD device has no gate lasers, so its
+  // groups share a mode and nothing more, and the ions must be shuttled to a
+  // zone that can act on them.
+  for (const auto& site : config.sites) {
+    const auto declared = substrate.lookupSite(site.name);
+    const auto rank = declared ? declared.getEffectiveFacetRank(deviceRank) : deviceRank;
+    for (const auto& group : site.groups) {
+      if (rank >= 2) {
+        add(group, rank);
+      } else if (group.size() >= 2) {
+        ungated.emplace_back(site.name, group);
+      }
+    }
+  }
+
+  // Persistent link edges are the second source: a superconducting coupler or a
+  // Rydberg blockade disc exists unconditionally, so it contributes a facet
+  // drawn from whichever qubits currently occupy its sites.
+  for (const auto edge : substrate.getEdgesOfKind(EdgeKind::Link)) {
+    if (!edge.isPersistent()) {
+      continue;
+    }
+    Word joined;
+    for (const auto site : edge.getSites()) {
+      if (const auto* contents = config.lookup(site.getValue())) {
+        for (const auto& group : *contents) {
+          llvm::append_range(joined, group);
+        }
+      }
+    }
+    add(std::move(joined), deviceRank);
+  }
+
+  // Live links are the third source, and the reason `K` is not a function of
+  // placement alone. A non-persistent link edge contributes nothing on its own,
+  // since it states only that a photon can be heralded there rather than that
+  // entanglement exists. Only a link produced by `qcc.link.generate` is a facet,
+  // and consuming it removes that facet.
+  for (const auto& link : config.links) {
+    add(link, deviceRank);
+  }
+
+  indexPartition();
+}
+
+void InteractionComplex::indexPartition() {
+  if (!device.getPartitioning()) {
+    return;
+  }
+  for (const auto& [index, facet] : llvm::enumerate(facets)) {
+    for (const int64_t qubit : facet.qubits) {
+      if (!facetOfQubit.try_emplace(qubit, static_cast<unsigned>(index)).second) {
+        // Two facets share a qubit, so `partitioning` does not hold of the
+        // facets actually derived here. Fall back to the search rather than
+        // answer from an index that is not a function.
+        facetOfQubit.clear();
+        return;
+      }
+    }
+  }
+  partitioned = true;
+}
+
+bool InteractionComplex::isExecutable(const llvm::ArrayRef<int64_t> qubits) const {
+  const Word wanted = normalize(qubits);
+  if (wanted.size() < 2) {
+    return true;
+  }
+  // The two paths answer the same question; only the cost differs. A partition
+  // admits a lookup because each qubit lies in exactly one facet, so the first
+  // operand names the only candidate. Overlapping facets admit no such index.
+  return partitioned ? isExecutableInPartition(wanted) : isExecutableByScan(wanted);
+}
+
+bool InteractionComplex::isExecutableInPartition(const Word& wanted) const {
+  const auto entry = facetOfQubit.find(wanted.front());
+  if (entry == facetOfQubit.end()) {
+    return false;
+  }
+  const Facet& facet = facets[entry->second];
+  // The rank cap belongs to the facet rather than the device: a set is
+  // executable only up to the width of whatever makes it a facet.
+  if (wanted.size() > facet.rank) {
+    return false;
+  }
+  for (const int64_t qubit : wanted) {
+    const auto other = facetOfQubit.find(qubit);
+    if (other == facetOfQubit.end() || other->second != entry->second) {
+      return false;
+    }
+  }
+  // Every operand is in this facet. Where the complex is downward closed that
+  // settles it; where it is not, the facet must be acted on whole, and since
+  // both words are sorted and deduplicated, equal sizes mean equal sets.
+  return device.getDownwardClosed() || wanted.size() == facet.qubits.size();
+}
+
+bool InteractionComplex::isExecutableByScan(const Word& wanted) const {
+  for (const auto& facet : facets) {
+    if (wanted.size() > facet.rank) {
+      continue;
+    }
+    // Where the complex is downward closed, any face of a facet is executable,
+    // since individual addressing lets an MS pulse select a subset of a chain.
+    // Where it is not, as on a machine offering only a global MS gate, the facet
+    // must be acted on as a whole, so only an exact match counts.
+    if (device.getDownwardClosed() ? isSubset(wanted, facet.qubits) : wanted == facet.qubits) {
+      return true;
+    }
+  }
+  return false;
+}
+
+std::string InteractionComplex::explain(const llvm::ArrayRef<int64_t> qubits) const {
+  const Word wanted = normalize(qubits);
+
+  std::string reason;
+  llvm::raw_string_ostream os(reason);
+
+  // Report co-location at an ungated site first: the qubits are together but
+  // the site cannot act on them, and the remedy is to shuttle them elsewhere.
+  for (const auto& [site, group] : ungated) {
+    if (isSubset(wanted, group)) {
+      os << "the qubits are co-located at @" << site
+         << ", but that site cannot host an entangling gate; they have to be moved to one that can";
+      return reason;
+    }
+  }
+
+  if (wanted.size() > device.getMaxFacetRank()) {
+    os << "it has " << wanted.size() << " qubits, above the device's maximum facet rank of "
+       << device.getMaxFacetRank();
+    return reason;
+  }
+
+  // A facet that contains the set but is too narrow for it is a different
+  // diagnosis from no facet at all, and calls for a different remedy.
+  for (const auto& facet : facets) {
+    if (isSubset(wanted, facet.qubits) && wanted.size() > facet.rank) {
+      os << "facet ";
+      printSet(os, facet.qubits);
+      os << " contains it, but that site hosts operations of at most " << facet.rank << " qubit(s)";
+      return reason;
+    }
+  }
+
+  if (!device.getDownwardClosed()) {
+    for (const auto& facet : facets) {
+      if (isSubset(wanted, facet.qubits)) {
+        os << "the device is not downward closed, so facet ";
+        printSet(os, facet.qubits);
+        os << " must be acted on whole rather than in part";
+        return reason;
+      }
+    }
+  }
+
+  os << "no facet of K contains it";
+  if (facets.empty()) {
+    os << " (K has no facet of rank 2 or more here)";
+  } else {
+    os << "; the facets here are ";
+    llvm::interleaveComma(facets, os, [&](const Facet& facet) { printSet(os, facet.qubits); });
+  }
+  return reason;
+}
+
+//===----------------------------------------------------------------------===//
+// ConfigurationAnalysis
+//===----------------------------------------------------------------------===//
+
+FailureOr<ConfigurationAnalysis::Result> ConfigurationAnalysis::get(const Value config) {
+  if (const auto cached = cache.find(config); cached != cache.end()) {
+    return cached->second;
+  }
+  if (invalid.contains(config)) {
+    return failure();
+  }
+
+  const auto fail = [&] {
+    invalid.insert(config);
+    return failure();
+  };
+  const auto remember = [&](Result result) {
+    cache.try_emplace(config, result);
+    return result;
+  };
+
+  // A block argument is where the fold stops. Inside an `scf.for` the
+  // configuration is loop-carried, and unless the body's net rewrite is the
+  // identity, no single placement describes the loop body.
+  if (llvm::isa<BlockArgument>(config)) {
+    return remember(Result{std::nullopt, config});
+  }
+
+  Operation* definition = config.getDefiningOp();
+  if (definition == nullptr) {
+    return remember(Result{std::nullopt, config});
+  }
+
+  if (auto init = llvm::dyn_cast<ConfigInitOp>(definition)) {
+    return remember(Result{init.getPlacement().toConfiguration(), Value{}});
+  }
+
+  auto rule = llvm::dyn_cast<TopologyRewriteOpInterface>(definition);
+  if (!rule) {
+    // The value was produced by an operation outside the rule set, such as an
+    // `scf.if`, whose result cannot be folded.
+    return remember(Result{std::nullopt, config});
+  }
+
+  if (!inFlight.insert(config).second) {
+    definition->emitOpError() << "configuration definition is cyclic";
+    return fail();
+  }
+  const llvm::scope_exit restore([&] { inFlight.erase(config); });
+
+  const auto incoming = get(rule.getInputConfig());
+  if (failed(incoming)) {
+    return fail();
+  }
+  if (!incoming->isKnown()) {
+    return remember(*incoming);
+  }
+
+  auto rewritten = rule.applyRule(*incoming->config);
+  if (failed(rewritten)) {
+    // `applyRule` has already reported why the rule does not apply here.
+    return fail();
+  }
+  return remember(Result{std::move(*rewritten), Value{}});
+}
+
+//===----------------------------------------------------------------------===//
+// Helpers
+//===----------------------------------------------------------------------===//
+
+std::optional<int64_t> getQubitIndex(const Value qubit) {
+  Operation* definition = qubit.getDefiningOp();
+  if (definition == nullptr) {
+    return std::nullopt;
+  }
+  if (auto staticQubit = llvm::dyn_cast<mlir::qc::StaticOp>(definition)) {
+    return static_cast<int64_t>(staticQubit.getIndex());
+  }
+  return std::nullopt;
+}
+
+//===----------------------------------------------------------------------===//
+// DominatingConfigMap
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+/// Whether `a` is available strictly before `b` is defined. `DominanceInfo`
+/// answers value-versus-operation directly; a block argument has no defining
+/// operation, so it is compared at the granularity of its block.
+bool definitionDominates(DominanceInfo& dominance, const Value a, const Value b) {
+  if (a == b) {
+    return false;
+  }
+  if (Operation* device = b.getDefiningOp()) {
+    return dominance.properlyDominates(a, device);
+  }
+
+  Block* targetBlock = llvm::cast<BlockArgument>(b).getOwner();
+  Block* sourceBlock =
+      a.getDefiningOp() != nullptr ? a.getDefiningOp()->getBlock() : llvm::cast<BlockArgument>(a).getOwner();
+  return dominance.properlyDominates(sourceBlock, targetBlock);
+}
+
+} // namespace
+
+DominatingConfigMap::DominatingConfigMap(Operation* function) : dominance(function) {
+  function->walk([&](Operation* candidate) {
+    for (const Value result : candidate->getResults()) {
+      if (llvm::isa<ConfigType>(result.getType())) {
+        candidates.push_back(result);
+      }
+    }
+    // Loop-carried configurations enter the body as block arguments, which are
+    // what dominates a gate inside the loop.
+    for (Region& region : candidate->getRegions()) {
+      for (Block& block : region) {
+        for (const BlockArgument argument : block.getArguments()) {
+          if (llvm::isa<ConfigType>(argument.getType())) {
+            candidates.push_back(argument);
+          }
+        }
+      }
+    }
+  });
+}
+
+DominatingConfigMap::Lookup DominatingConfigMap::at(Operation* op) {
+  llvm::SmallVector<Value> dominating;
+  for (const Value candidate : candidates) {
+    if (dominance.properlyDominates(candidate, op)) {
+      dominating.push_back(candidate);
+    }
+  }
+  if (dominating.empty()) {
+    return {};
+  }
+
+  // The connectivity in force is the latest dominating definition, that is, the
+  // one every other dominating definition itself dominates.
+  for (const Value candidate : dominating) {
+    if (llvm::all_of(dominating, [&](const Value other) {
+          return other == candidate || definitionDominates(dominance, other, candidate);
+        })) {
+      return {candidate, false};
+    }
+  }
+  return {Value{}, true};
+}
+
+} // namespace qcc::conn

--- a/mlir/lib/Dialect/QCC/CMakeLists.txt
+++ b/mlir/lib/Dialect/QCC/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_subdirectory(IR)
+add_subdirectory(Analysis)
+add_subdirectory(Devices)
+add_subdirectory(Transforms)

--- a/mlir/lib/Dialect/QCC/Devices/BuiltinDevices.cpp
+++ b/mlir/lib/Dialect/QCC/Devices/BuiltinDevices.cpp
@@ -1,0 +1,304 @@
+// ===----------------------------------------------------------------------===//
+//
+// Part of the FullStaQD Project, under the Apache License v2.0 with LLVM
+// Exceptions.
+// See <repo-root>/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// ===----------------------------------------------------------------------===//
+//
+// The machines compiled into this build.
+//
+// These describe topologies and rule sets, not calibrated devices: the
+// latencies are order-of-magnitude and no error rates are claimed. They make
+// `--device=<name>` usable without further setup. A real machine arrives
+// through QDMI or as a hand-written `#qcc.device` attribute, and neither
+// requires changes here.
+//
+// The names describe the topology rather than a vendor, since a vendor name
+// would imply calibration data that is not present.
+//
+// ===----------------------------------------------------------------------===//
+
+#include "qcc/Dialect/QCC/Devices/DeviceLibrary.h"
+#include "qcc/Dialect/QCC/IR/QCC.h"
+
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/Diagnostics.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/Support/LLVM.h"
+
+#include <cstdint>
+#include <llvm/ADT/ArrayRef.h>
+#include <llvm/ADT/SmallVector.h>
+#include <llvm/ADT/StringRef.h>
+#include <string>
+
+using namespace mlir;
+
+namespace qcc::conn {
+
+namespace {
+
+/// An edge of `kind` over `members`, carrying `id` and any extra properties.
+HyperedgeAttr edge(MLIRContext* ctx, EdgeKind kind, llvm::ArrayRef<llvm::StringRef> members, llvm::StringRef id,
+                   llvm::ArrayRef<NamedAttribute> extra = {}) {
+  Builder builder(ctx);
+  llvm::SmallVector<FlatSymbolRefAttr> refs;
+  for (const auto member : members) {
+    refs.push_back(FlatSymbolRefAttr::get(ctx, member));
+  }
+  llvm::SmallVector<NamedAttribute> props{builder.getNamedAttr("id", builder.getStringAttr(id))};
+  llvm::append_range(props, extra);
+  return HyperedgeAttr::get(ctx, kind, llvm::ArrayRef<FlatSymbolRefAttr>(refs), builder.getDictionaryAttr(props));
+}
+
+/// A zone site of the given capacity, at an optional position.
+SiteSnapshot zone(llvm::StringRef name, uint64_t capacity) {
+  SiteSnapshot site;
+  site.name = name.str();
+  site.isZone = true;
+  site.capacity = capacity;
+  return site;
+}
+
+/// A single-qubit site on a grid.
+SiteSnapshot cell(llvm::StringRef name, double x, double y) {
+  SiteSnapshot site;
+  site.name = name.str();
+  site.isZone = false;
+  site.position = std::array<double, 3>{x, y, 0.0};
+  return site;
+}
+
+/// A malformed built-in is a bug in this file rather than in a user program, so
+/// its diagnostics go to the context.
+DeviceAttr finish(MLIRContext* ctx, const DeviceSnapshot& snapshot, const DeviceSupplement& supplement) {
+  const auto device = buildDevice(ctx, snapshot, supplement, [&] { return emitError(UnknownLoc::get(ctx)); });
+  return succeeded(device) ? *device : DeviceAttr{};
+}
+
+//===----------------------------------------------------------------------===//
+// Superconducting: a 4x4 grid of fixed qubits.
+//
+// The degenerate case: no transport, no rigid axes, every link permanent. The
+// rule set is empty, so a configuration threaded through such a program never
+// changes.
+//===----------------------------------------------------------------------===//
+
+DeviceAttr buildScGrid4x4(MLIRContext* ctx) {
+  constexpr unsigned kSide = 4;
+
+  DeviceSnapshot snapshot;
+  snapshot.name = "sc-grid-4x4";
+  snapshot.maxOperationArity = 2;
+  for (unsigned row = 0; row < kSide; ++row) {
+    for (unsigned col = 0; col < kSide; ++col) {
+      snapshot.sites.push_back(cell("q" + std::to_string((row * kSide) + col), col, row));
+    }
+  }
+  for (unsigned row = 0; row < kSide; ++row) {
+    for (unsigned col = 0; col < kSide; ++col) {
+      const unsigned here = (row * kSide) + col;
+      if (col + 1 < kSide) {
+        snapshot.couplings.emplace_back(here, here + 1);
+      }
+      if (row + 1 < kSide) {
+        snapshot.couplings.emplace_back(here, here + kSide);
+      }
+    }
+  }
+  // The coupling map is the whole machine, so no supplement is needed.
+  return finish(ctx, snapshot, DeviceSupplement{});
+}
+
+//===----------------------------------------------------------------------===//
+// QCCD ions: two storage traps either side of a junction.
+//
+// The smallest machine on which shuttling matters. The segments, the shared
+// waveform generator and the chain order all live in the supplement, having no
+// coupling-map spelling.
+//===----------------------------------------------------------------------===//
+
+DeviceAttr buildQccdLinear2(MLIRContext* ctx) {
+  Builder builder(ctx);
+  const auto latency = [&](double us) { return builder.getNamedAttr("latency_us", builder.getF64FloatAttr(us)); };
+  const auto maxLen = builder.getNamedAttr("max_chain_len", builder.getI64IntegerAttr(10));
+  const auto bidirectional = builder.getNamedAttr("bidirectional", builder.getBoolAttr(true));
+
+  DeviceSnapshot snapshot;
+  snapshot.name = "qccd-linear-2";
+  snapshot.maxOperationArity = 10;
+  snapshot.sites = {zone("trap_a", 20), zone("j0", 10), zone("trap_b", 20)};
+  // No couplings: a gate is possible through co-location inside a trap, which
+  // is a property of the configuration rather than of the substrate.
+
+  DeviceSupplement supplement;
+  supplement.sites = {
+      {"trap_a", SiteKind::Trap, 20, std::nullopt, {}},
+      {"j0", SiteKind::Junction, 10, std::nullopt, {}},
+      {"trap_b", SiteKind::Trap, 20, std::nullopt, {}},
+  };
+  supplement.edges = {
+      edge(ctx, EdgeKind::Transport, {"trap_a", "j0"}, "seg_aj", {latency(80.0), bidirectional, maxLen}),
+      edge(ctx, EdgeKind::Transport, {"j0", "trap_b"}, "seg_jb", {latency(80.0), bidirectional, maxLen}),
+      // One generator drives every shuttling electrode, so no two transports
+      // may overlap in time even on disjoint segments.
+      edge(ctx, EdgeKind::Control, {"trap_a", "j0", "trap_b"}, "awg_shuttle"),
+      // One MS laser, switched between the traps.
+      edge(ctx, EdgeKind::Control, {"trap_a", "trap_b"}, "laser_ms"),
+  };
+  supplement.maxFacetRank = 10;
+  supplement.downwardClosed = true;
+  supplement.partitioning = true;
+  supplement.facetOrdering = FacetOrdering::Linear;
+  return finish(ctx, snapshot, supplement);
+}
+
+//===----------------------------------------------------------------------===//
+// QCCD ions, H-series shape: a storage trap and a small gate zone.
+//
+// Storage holds thirty ions and gates none of them, so a program shuttles a
+// pair into the gate zone before acting on them. Without `maxFacetRank = 0` on
+// storage the compiler would accept gates the hardware cannot perform.
+//===----------------------------------------------------------------------===//
+
+DeviceAttr buildQccdStorageGate(MLIRContext* ctx) {
+  Builder builder(ctx);
+  const auto latency = [&](double us) { return builder.getNamedAttr("latency_us", builder.getF64FloatAttr(us)); };
+  const auto maxLen = builder.getNamedAttr("max_chain_len", builder.getI64IntegerAttr(2));
+  const auto bidirectional = builder.getNamedAttr("bidirectional", builder.getBoolAttr(true));
+
+  DeviceSnapshot snapshot;
+  snapshot.name = "qccd-storage-gate";
+  snapshot.maxOperationArity = 2;
+  snapshot.sites = {zone("storage", 30), zone("j0", 4), zone("gate", 2)};
+
+  DeviceSupplement supplement;
+  // Storage and the junction are places to be, not places to be acted on. The
+  // gate zone declares nothing and inherits the device rank of 2.
+  supplement.sites = {
+      {"storage", SiteKind::Trap, 30, 0, {}},
+      {"j0", SiteKind::Junction, 4, 0, {}},
+      {"gate", SiteKind::GateZone, 2, std::nullopt, {}},
+  };
+  supplement.edges = {
+      edge(ctx, EdgeKind::Transport, {"storage", "j0"}, "seg_sj", {latency(100.0), bidirectional, maxLen}),
+      edge(ctx, EdgeKind::Transport, {"j0", "gate"}, "seg_jg", {latency(60.0), bidirectional, maxLen}),
+      edge(ctx, EdgeKind::Control, {"storage", "j0", "gate"}, "awg_shuttle"),
+  };
+  supplement.maxFacetRank = 2;
+  supplement.downwardClosed = true;
+  supplement.partitioning = true;
+  supplement.facetOrdering = FacetOrdering::Linear;
+  return finish(ctx, snapshot, supplement);
+}
+
+//===----------------------------------------------------------------------===//
+// Neutral atoms: a 3x3 SLM array under a crossed AOD.
+//
+// The blockade discs are derived from the trap positions and the blockade
+// radius rather than listed, so moving a trap moves its disc.
+//===----------------------------------------------------------------------===//
+
+DeviceAttr buildNeutralAtom3x3(MLIRContext* ctx) {
+  constexpr unsigned kSide = 3;
+  Builder builder(ctx);
+  const auto axis = [&](llvm::StringRef which) { return builder.getNamedAttr("axis", builder.getStringAttr(which)); };
+
+  DeviceSnapshot snapshot;
+  snapshot.name = "neutral-atom-3x3";
+  snapshot.maxOperationArity = 3;
+  for (unsigned row = 0; row < kSide; ++row) {
+    for (unsigned col = 0; col < kSide; ++col) {
+      snapshot.sites.push_back(cell("t" + std::to_string(row) + std::to_string(col), col, row));
+    }
+  }
+  // On a unit grid this radius reaches the four edge neighbours, so an atom in
+  // the middle belongs to five overlapping discs.
+  snapshot.minAtomDistance = 1.0;
+
+  DeviceSupplement supplement;
+  // An AOD row or column moves as a unit. This has no coupling-map spelling: it
+  // says which atoms must move together, not which can interact.
+  supplement.edges = {
+      edge(ctx, EdgeKind::Rigid, {"t00", "t01", "t02"}, "aod_row_0", {axis("x")}),
+      edge(ctx, EdgeKind::Rigid, {"t10", "t11", "t12"}, "aod_row_1", {axis("x")}),
+      edge(ctx, EdgeKind::Rigid, {"t20", "t21", "t22"}, "aod_row_2", {axis("x")}),
+      edge(ctx, EdgeKind::Rigid, {"t00", "t10", "t20"}, "aod_col_0", {axis("y")}),
+      edge(ctx, EdgeKind::Rigid, {"t01", "t11", "t21"}, "aod_col_1", {axis("y")}),
+      edge(ctx, EdgeKind::Rigid, {"t02", "t12", "t22"}, "aod_col_2", {axis("y")}),
+  };
+  supplement.maxFacetRank = 3;
+  supplement.downwardClosed = true;
+  supplement.partitioning = false;
+  supplement.facetOrdering = FacetOrdering::None;
+  return finish(ctx, snapshot, supplement);
+}
+
+//===----------------------------------------------------------------------===//
+// Modular photonic: three modules on an optical switch.
+//
+// The interconnects are consumable, so they are supplied rather than derived
+// from the coupling map: a reported coupling means the pair can interact, and a
+// heralded Bell pair means it can interact once.
+//===----------------------------------------------------------------------===//
+
+DeviceAttr buildModularPhotonic3(MLIRContext* ctx) {
+  Builder builder(ctx);
+  const auto consumable = builder.getNamedAttr("persistent", builder.getBoolAttr(false));
+  const auto latency = [&](double us) { return builder.getNamedAttr("latency_us", builder.getF64FloatAttr(us)); };
+
+  DeviceSnapshot snapshot;
+  snapshot.name = "modular-photonic-3";
+  snapshot.maxOperationArity = 2;
+  for (unsigned module = 0; module < 3; ++module) {
+    auto site = zone("m" + std::to_string(module), 4);
+    site.moduleIndex = module;
+    snapshot.sites.push_back(site);
+  }
+
+  DeviceSupplement supplement;
+  supplement.sites = {
+      {"m0", SiteKind::Module, 4, std::nullopt, {}},
+      {"m1", SiteKind::Module, 4, std::nullopt, {}},
+      {"m2", SiteKind::Module, 4, std::nullopt, {}},
+  };
+  supplement.edges = {
+      edge(ctx, EdgeKind::Link, {"m0", "m1"}, "fibre_01", {consumable, latency(5500.0)}),
+      edge(ctx, EdgeKind::Link, {"m1", "m2"}, "fibre_12", {consumable, latency(6100.0)}),
+      // One heralding detector array serves every module.
+      edge(ctx, EdgeKind::Control, {"m0", "m1", "m2"}, "bsa_detector"),
+  };
+  supplement.maxFacetRank = 2;
+  supplement.downwardClosed = true;
+  supplement.partitioning = false;
+  supplement.facetOrdering = FacetOrdering::None;
+  return finish(ctx, snapshot, supplement);
+}
+
+const DeviceEntry builtinDevices[] = {
+    {"sc-grid-4x4", "Superconducting 4x4 lattice; static coupling, empty rule set", buildScGrid4x4},
+    {"qccd-linear-2", "Trapped-ion QCCD: two traps either side of a junction, with shuttling", buildQccdLinear2},
+    {"qccd-storage-gate", "Trapped-ion QCCD: a storage trap that cannot gate, and a two-ion gate zone",
+     buildQccdStorageGate},
+    {"neutral-atom-3x3", "Neutral atoms: 3x3 SLM array under a crossed AOD, blockade discs derived from geometry",
+     buildNeutralAtom3x3},
+    {"modular-photonic-3", "Three modules on an optical switch; interconnects consumed by use", buildModularPhotonic3},
+};
+
+} // namespace
+
+llvm::ArrayRef<DeviceEntry> getDevices() { return builtinDevices; }
+
+const DeviceEntry* lookupDevice(const llvm::StringRef name) {
+  for (const auto& entry : builtinDevices) {
+    if (entry.name == name) {
+      return &entry;
+    }
+  }
+  return nullptr;
+}
+
+} // namespace qcc::conn

--- a/mlir/lib/Dialect/QCC/Devices/CMakeLists.txt
+++ b/mlir/lib/Dialect/QCC/Devices/CMakeLists.txt
@@ -1,0 +1,30 @@
+set(QCC_DEVICE_SOURCES DeviceLibrary.cpp BuiltinDevices.cpp)
+
+# The QDMI importer is the only part that needs a live device-management session, so it is compiled in only when QDMI is
+# present.
+if(TARGET qdmi::qdmi)
+  list(APPEND QCC_DEVICE_SOURCES QDMIImport.cpp)
+endif()
+
+add_mlir_library(
+  QCCQCCDevices
+  ${QCC_DEVICE_SOURCES}
+  DEPENDS
+  QCCQCCEnumsIncGen
+  QCCQCCDialectIncGen
+  QCCQCCAttributesIncGen
+  QCCQCCTypesIncGen
+  QCCQCCInterfacesIncGen
+  QCCQCCOpsIncGen
+  LINK_LIBS
+  PUBLIC
+  QCCQCCDialect
+  MLIRIR
+  MLIRSupport)
+
+if(TARGET qdmi::qdmi)
+  target_link_libraries(QCCQCCDevices PUBLIC qdmi::qdmi)
+  target_compile_definitions(QCCQCCDevices PUBLIC QCC_HAVE_QDMI=1)
+endif()
+
+mqt_mlir_target_use_project_options(QCCQCCDevices)

--- a/mlir/lib/Dialect/QCC/Devices/DeviceLibrary.cpp
+++ b/mlir/lib/Dialect/QCC/Devices/DeviceLibrary.cpp
@@ -1,0 +1,183 @@
+// ===----------------------------------------------------------------------===//
+//
+// Part of the FullStaQD Project, under the Apache License v2.0 with LLVM
+// Exceptions.
+// See <repo-root>/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// ===----------------------------------------------------------------------===//
+
+#include "qcc/Dialect/QCC/Devices/DeviceLibrary.h"
+
+#include "qcc/Dialect/QCC/IR/QCC.h"
+
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/MLIRContext.h"
+#include "mlir/Support/LLVM.h"
+
+#include <cmath>
+#include <cstdint>
+#include <llvm/ADT/ArrayRef.h>
+#include <llvm/ADT/STLExtras.h>
+#include <llvm/ADT/SmallVector.h>
+#include <llvm/ADT/StringSet.h>
+#include <optional>
+#include <string>
+
+using namespace mlir;
+
+namespace qcc::conn {
+
+namespace {
+
+/// Euclidean distance between two sites, when both carry a position.
+std::optional<double> distance(const SiteSnapshot& a, const SiteSnapshot& b) {
+  if (!a.position || !b.position) {
+    return std::nullopt;
+  }
+  double sum = 0.0;
+  for (unsigned axis = 0; axis < 3; ++axis) {
+    const double delta = (*a.position)[axis] - (*b.position)[axis];
+    sum += delta * delta;
+  }
+  return std::sqrt(sum);
+}
+
+/// Builds the `#qcc.site` attributes, applying any supplied overrides.
+FailureOr<llvm::SmallVector<SiteAttr>> buildSites(MLIRContext* ctx, const DeviceSnapshot& snapshot,
+                                                  const DeviceSupplement& supplement,
+                                                  const std::function<InFlightDiagnostic()>& emitError) {
+  llvm::StringSet<> seen;
+  llvm::SmallVector<SiteAttr> sites;
+
+  for (const auto& site : snapshot.sites) {
+    if (!seen.insert(site.name).second) {
+      return emitError() << "device '" << snapshot.name << "' reports site '" << site.name << "' twice";
+    }
+    const auto* override_ = supplement.find(site.name);
+
+    // A device-management interface reports only zone or not-zone. Which kind
+    // of zone a site is must come from the supplement.
+    auto kind = site.isZone ? SiteKind::Trap : SiteKind::Fixed;
+    if (override_ && override_->kind) {
+      kind = *override_->kind;
+    }
+
+    uint64_t capacity = site.capacity;
+    if (override_ && override_->capacity) {
+      capacity = *override_->capacity;
+    }
+    if (kind == SiteKind::Fixed) {
+      capacity = 1;
+    }
+
+    DenseF64ArrayAttr coords;
+    if (site.position) {
+      coords = DenseF64ArrayAttr::get(ctx, *site.position);
+    }
+
+    sites.push_back(SiteAttr::get(ctx, FlatSymbolRefAttr::get(ctx, site.name), kind, capacity,
+                                  override_ ? override_->maxFacetRank : std::nullopt, std::nullopt, coords,
+                                  override_ ? override_->props : DictionaryAttr{}));
+  }
+  return sites;
+}
+
+/// Builds the link edges implied by the snapshot: one per reported coupling,
+/// plus one blockade disc per site when a blockade radius is given.
+///
+/// A reported coupling is a permanent interaction, since nothing on a machine
+/// described this way moves the pair apart.
+FailureOr<llvm::SmallVector<HyperedgeAttr>> buildDerivedEdges(MLIRContext* ctx, const DeviceSnapshot& snapshot,
+                                                              const std::function<InFlightDiagnostic()>& emitError) {
+  Builder builder(ctx);
+  llvm::SmallVector<HyperedgeAttr> edges;
+
+  const auto persistentLink = [&](const std::string& id, llvm::ArrayRef<unsigned> members) {
+    llvm::SmallVector<FlatSymbolRefAttr> refs;
+    for (const unsigned member : members) {
+      refs.push_back(FlatSymbolRefAttr::get(ctx, snapshot.sites[member].name));
+    }
+    const NamedAttribute props[] = {
+        builder.getNamedAttr("id", builder.getStringAttr(id)),
+        builder.getNamedAttr("persistent", builder.getBoolAttr(true)),
+    };
+    return HyperedgeAttr::get(ctx, EdgeKind::Link, llvm::ArrayRef<FlatSymbolRefAttr>(refs),
+                              builder.getDictionaryAttr(props));
+  };
+
+  for (const auto& [a, b] : snapshot.couplings) {
+    if (a >= snapshot.sites.size() || b >= snapshot.sites.size()) {
+      return emitError() << "device '" << snapshot.name << "' reports a coupling between sites " << a << " and " << b
+                         << ", but only declares " << snapshot.sites.size() << " site(s)";
+    }
+    const unsigned members[] = {a, b};
+    edges.push_back(persistentLink("coupler_" + snapshot.sites[a].name + "_" + snapshot.sites[b].name, members));
+  }
+
+  // A blockade disc follows from the radius and the trap positions rather than
+  // being listed, so moving a trap moves its disc.
+  if (snapshot.minAtomDistance) {
+    for (const auto& [i, site] : llvm::enumerate(snapshot.sites)) {
+      llvm::SmallVector<unsigned> disc{static_cast<unsigned>(i)};
+      for (const auto& [j, other] : llvm::enumerate(snapshot.sites)) {
+        const auto separation = i == j ? std::nullopt : distance(site, other);
+        if (separation && *separation <= *snapshot.minAtomDistance) {
+          disc.push_back(static_cast<unsigned>(j));
+        }
+      }
+      if (disc.size() >= 2) {
+        edges.push_back(persistentLink("blockade_" + site.name, disc));
+      }
+    }
+  }
+
+  return edges;
+}
+
+} // namespace
+
+FailureOr<DeviceAttr> buildDevice(MLIRContext* ctx, const DeviceSnapshot& snapshot, const DeviceSupplement& supplement,
+                                  const std::function<InFlightDiagnostic()>& emitError) {
+  const auto sites = buildSites(ctx, snapshot, supplement, emitError);
+  if (failed(sites)) {
+    return failure();
+  }
+
+  auto edges = buildDerivedEdges(ctx, snapshot, emitError);
+  if (failed(edges)) {
+    return failure();
+  }
+
+  for (const auto edge : supplement.edges) {
+    for (const auto member : edge.getSites()) {
+      const bool declared =
+          llvm::any_of(*sites, [&](const SiteAttr site) { return site.getSymName() == member.getValue(); });
+      if (!declared) {
+        return emitError() << "supplementary edge '" << edge.getId() << "' names site @" << member.getValue()
+                           << ", which device '" << snapshot.name << "' does not report";
+      }
+    }
+    edges->push_back(edge);
+  }
+
+  const auto substrate = SubstrateAttr::getChecked(emitError, ctx, llvm::ArrayRef<SiteAttr>(*sites),
+                                                   llvm::ArrayRef<HyperedgeAttr>(*edges));
+  if (!substrate) {
+    return failure();
+  }
+
+  // The defaults describe a coupling-graph machine, which is all a snapshot on
+  // its own supports. A machine with chains states its own.
+  const auto device = DeviceAttr::getChecked(
+      emitError, ctx, substrate, supplement.maxFacetRank.value_or(std::max<uint64_t>(snapshot.maxOperationArity, 2)),
+      supplement.downwardClosed.value_or(true), supplement.partitioning.value_or(false),
+      supplement.facetOrdering.value_or(FacetOrdering::None));
+  if (!device) {
+    return failure();
+  }
+  return device;
+}
+
+} // namespace qcc::conn

--- a/mlir/lib/Dialect/QCC/Devices/QDMIImport.cpp
+++ b/mlir/lib/Dialect/QCC/Devices/QDMIImport.cpp
@@ -1,0 +1,178 @@
+// ===----------------------------------------------------------------------===//
+//
+// Part of the FullStaQD Project, under the Apache License v2.0 with LLVM
+// Exceptions.
+// See <repo-root>/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// ===----------------------------------------------------------------------===//
+
+#include "qcc/Dialect/QCC/Devices/QDMIImport.h"
+
+#include "qcc/Dialect/QCC/Devices/DeviceLibrary.h"
+
+#include "mlir/Support/LLVM.h"
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <llvm/ADT/SmallVector.h>
+#include <qdmi/constants.h>
+#include <qdmi/device.h>
+#include <qdmi/types.h>
+#include <string>
+#include <vector>
+
+using namespace mlir;
+
+namespace qcc::conn {
+
+namespace {
+
+/// Query a fixed-size device property. Returns false when the device does not
+/// offer it, which is normal: most properties are optional.
+template <typename T> bool queryDevice(QDMI_Device_Session session, const QDMI_Device_Property prop, T& out) {
+  return QDMI_device_session_query_device_property(session, prop, sizeof(T), &out, nullptr) == QDMI_SUCCESS;
+}
+
+/// Query a variable-length device property, sizing the buffer from the device.
+template <typename T>
+bool queryDeviceList(QDMI_Device_Session session, const QDMI_Device_Property prop, std::vector<T>& out) {
+  size_t bytes = 0;
+  if (QDMI_device_session_query_device_property(session, prop, 0, nullptr, &bytes) != QDMI_SUCCESS || bytes == 0) {
+    return false;
+  }
+  out.resize(bytes / sizeof(T));
+  return QDMI_device_session_query_device_property(session, prop, bytes, out.data(), nullptr) == QDMI_SUCCESS;
+}
+
+template <typename T>
+bool querySite(QDMI_Device_Session session, QDMI_Site site, const QDMI_Site_Property prop, T& out) {
+  return QDMI_device_session_query_site_property(session, site, prop, sizeof(T), &out, nullptr) == QDMI_SUCCESS;
+}
+
+bool querySiteName(QDMI_Device_Session session, QDMI_Site site, std::string& out) {
+  size_t bytes = 0;
+  if (QDMI_device_session_query_site_property(session, site, QDMI_SITE_PROPERTY_NAME, 0, nullptr, &bytes) !=
+          QDMI_SUCCESS ||
+      bytes == 0) {
+    return false;
+  }
+  out.resize(bytes);
+  if (QDMI_device_session_query_site_property(session, site, QDMI_SITE_PROPERTY_NAME, bytes, out.data(), nullptr) !=
+      QDMI_SUCCESS) {
+    return false;
+  }
+  // QDMI returns a NUL-terminated buffer; the terminator is not part of the name
+  // used as a symbol.
+  if (!out.empty() && out.back() == '\0') {
+    out.pop_back();
+  }
+  return true;
+}
+
+} // namespace
+
+bool isQDMIAvailable() { return true; }
+
+FailureOr<DeviceSnapshot> queryDeviceSnapshot(void* opaqueSession) {
+  auto* session = static_cast<QDMI_Device_Session>(opaqueSession);
+  if (session == nullptr) {
+    return failure();
+  }
+
+  DeviceSnapshot snapshot;
+
+  //--- Name ------------------------------------------------------------------
+  size_t nameBytes = 0;
+  if (QDMI_device_session_query_device_property(session, QDMI_DEVICE_PROPERTY_NAME, 0, nullptr, &nameBytes) ==
+          QDMI_SUCCESS &&
+      nameBytes > 0) {
+    snapshot.name.resize(nameBytes);
+    if (QDMI_device_session_query_device_property(session, QDMI_DEVICE_PROPERTY_NAME, nameBytes, snapshot.name.data(),
+                                                  nullptr) != QDMI_SUCCESS) {
+      return failure();
+    }
+    if (!snapshot.name.empty() && snapshot.name.back() == '\0') {
+      snapshot.name.pop_back();
+    }
+  }
+
+  //--- Sites -----------------------------------------------------------------
+  std::vector<QDMI_Site> sites;
+  if (!queryDeviceList(session, QDMI_DEVICE_PROPERTY_SITES, sites)) {
+    return failure();
+  }
+
+  llvm::SmallVector<QDMI_Site> order;
+  for (const auto site : sites) {
+    SiteSnapshot entry;
+    if (!querySiteName(session, site, entry.name)) {
+      // A site with no name of its own is addressed by index, and the dialect
+      // addresses sites by symbol, so synthesise one.
+      size_t index = 0;
+      querySite(session, site, QDMI_SITE_PROPERTY_INDEX, index);
+      entry.name = "s" + std::to_string(index);
+    }
+
+    // A zone holds many qubits; a plain site holds one. Which *kind* of zone it
+    // is has no QDMI spelling, so it stays a trap until a supplement says
+    // otherwise.
+    if (int isZone = 0; querySite(session, site, QDMI_SITE_PROPERTY_ISZONE, isZone)) {
+      entry.isZone = isZone != 0;
+    }
+
+    // A position needs at least two axes to be one; the third defaults to zero
+    // for the planar layouts most devices report.
+    double x = 0.0;
+    double y = 0.0;
+    if (querySite(session, site, QDMI_SITE_PROPERTY_XCOORDINATE, x) &&
+        querySite(session, site, QDMI_SITE_PROPERTY_YCOORDINATE, y)) {
+      double z = 0.0;
+      querySite(session, site, QDMI_SITE_PROPERTY_ZCOORDINATE, z);
+      entry.position = std::array<double, 3>{x, y, z};
+    }
+    if (size_t module = 0; querySite(session, site, QDMI_SITE_PROPERTY_MODULEINDEX, module)) {
+      entry.moduleIndex = module;
+    }
+
+    order.push_back(site);
+    snapshot.sites.push_back(std::move(entry));
+  }
+
+  //--- Coupling map ----------------------------------------------------------
+  // Reported as a flat list of site pairs. Every reported pair is a permanent
+  // interaction, which `buildDevice` turns into a persistent link edge.
+  std::vector<QDMI_Site> couplings;
+  if (queryDeviceList(session, QDMI_DEVICE_PROPERTY_COUPLINGMAP, couplings)) {
+    const auto indexOf = [&](QDMI_Site site) -> unsigned {
+      for (const auto& [index, candidate] : llvm::enumerate(order)) {
+        if (candidate == site) {
+          return static_cast<unsigned>(index);
+        }
+      }
+      return static_cast<unsigned>(order.size());
+    };
+    for (size_t i = 0; i + 1 < couplings.size(); i += 2) {
+      const unsigned a = indexOf(couplings[i]);
+      const unsigned b = indexOf(couplings[i + 1]);
+      if (a < order.size() && b < order.size()) {
+        snapshot.couplings.emplace_back(a, b);
+      }
+    }
+  }
+
+  //--- Blockade radius -------------------------------------------------------
+  if (double distance = 0.0; queryDevice(session, QDMI_DEVICE_PROPERTY_MINATOMDISTANCE, distance) && distance > 0.0) {
+    snapshot.minAtomDistance = distance;
+  }
+
+  // QDMI reports operations, but their arity is a per-operation property whose
+  // spelling varies by device. Two is the safe floor: a machine that could not
+  // entangle a pair would have nothing to route.
+  snapshot.maxOperationArity = 2;
+
+  return snapshot;
+}
+
+} // namespace qcc::conn

--- a/mlir/lib/Dialect/QCC/IR/CMakeLists.txt
+++ b/mlir/lib/Dialect/QCC/IR/CMakeLists.txt
@@ -1,0 +1,18 @@
+add_mlir_dialect_library(
+  QCCQCCDialect
+  QCCDialect.cpp
+  QCCOps.cpp
+  DEPENDS
+  QCCQCCEnumsIncGen
+  QCCQCCDialectIncGen
+  QCCQCCAttributesIncGen
+  QCCQCCTypesIncGen
+  QCCQCCInterfacesIncGen
+  QCCQCCOpsIncGen
+  LINK_LIBS
+  PUBLIC
+  MLIRIR
+  MLIRSupport
+  MLIRSideEffectInterfaces)
+
+mqt_mlir_target_use_project_options(QCCQCCDialect)

--- a/mlir/lib/Dialect/QCC/IR/QCCDialect.cpp
+++ b/mlir/lib/Dialect/QCC/IR/QCCDialect.cpp
@@ -1,0 +1,628 @@
+// ===----------------------------------------------------------------------===//
+//
+// Part of the FullStaQD Project, under the Apache License v2.0 with LLVM
+// Exceptions.
+// See <repo-root>/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// ===----------------------------------------------------------------------===//
+
+#include "qcc/Dialect/QCC/IR/QCC.h"
+
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinAttributes.h"
+#include "mlir/IR/DialectImplementation.h"
+#include "mlir/IR/OpImplementation.h"
+#include "mlir/Support/LLVM.h"
+
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <llvm/ADT/DenseSet.h>
+#include <llvm/ADT/STLExtras.h>
+#include <llvm/ADT/SmallVector.h>
+#include <llvm/ADT/StringRef.h>
+#include <llvm/ADT/StringSet.h>
+#include <llvm/ADT/TypeSwitch.h> // IWYU pragma: keep
+#include <optional>
+#include <string>
+
+using namespace mlir;
+using namespace qcc::conn;
+
+#include "qcc/Dialect/QCC/IR/QCCDialect.cpp.inc"
+#include "qcc/Dialect/QCC/IR/QCCEnums.cpp.inc"
+
+#define GET_ATTRDEF_CLASSES
+#include "qcc/Dialect/QCC/IR/QCCAttributes.cpp.inc"
+
+#define GET_TYPEDEF_CLASSES
+#include "qcc/Dialect/QCC/IR/QCCTypes.cpp.inc"
+
+void QCCDialect::initialize() {
+  addAttributes<
+#define GET_ATTRDEF_LIST
+#include "qcc/Dialect/QCC/IR/QCCAttributes.cpp.inc"
+      >();
+
+  addTypes<
+#define GET_TYPEDEF_LIST
+#include "qcc/Dialect/QCC/IR/QCCTypes.cpp.inc"
+      >();
+
+  addOperations<
+#define GET_OP_LIST
+#include "qcc/Dialect/QCC/IR/QCCOps.cpp.inc"
+      >();
+}
+
+//===----------------------------------------------------------------------===//
+// SiteAttr
+//===----------------------------------------------------------------------===//
+
+bool SiteAttr::permitsTurn(const llvm::StringRef from, const llvm::StringRef to) const {
+  const auto props = getProps();
+  if (!props) {
+    return true;
+  }
+  const auto turns = props.getAs<ArrayAttr>("turns");
+  // No table means no restriction: a junction that declares no turns permits
+  // every rotation.
+  if (!turns) {
+    return true;
+  }
+  const std::string wanted = (from + ">" + to).str();
+  return llvm::any_of(turns, [&](const Attribute entry) {
+    const auto name = llvm::dyn_cast<StringAttr>(entry);
+    return name && name.getValue() == wanted;
+  });
+}
+
+double SiteAttr::getTurnLatencyUs() const {
+  const auto props = getProps();
+  if (!props) {
+    return 0.0;
+  }
+  if (const auto latency = props.getAs<FloatAttr>("turn_latency_us")) {
+    return latency.getValueAsDouble();
+  }
+  if (const auto latency = props.getAs<IntegerAttr>("turn_latency_us")) {
+    return static_cast<double>(latency.getInt());
+  }
+  return 0.0;
+}
+
+std::optional<std::array<double, 3>> SiteAttr::getPosition() const {
+  const auto coords = getCoords();
+  if (!coords || coords.size() < 2) {
+    return std::nullopt;
+  }
+  return std::array<double, 3>{coords[0], coords[1], coords.size() > 2 ? coords[2] : 0.0};
+}
+
+std::optional<double> SiteAttr::distanceTo(const SiteAttr other) const {
+  const auto here = getPosition();
+  const auto there = other ? other.getPosition() : std::nullopt;
+  if (!here || !there) {
+    return std::nullopt;
+  }
+  const double dx = (*here)[0] - (*there)[0];
+  const double dy = (*here)[1] - (*there)[1];
+  const double dz = (*here)[2] - (*there)[2];
+  return std::sqrt((dx * dx) + (dy * dy) + (dz * dz));
+}
+
+LogicalResult SiteAttr::verify(const llvm::function_ref<InFlightDiagnostic()> emitError, const FlatSymbolRefAttr name,
+                               const SiteKind kind, const uint64_t capacity, const std::optional<uint64_t> maxFacetRank,
+                               const std::optional<FacetOrdering> /*facetOrdering*/, const DenseF64ArrayAttr coords,
+                               const DictionaryAttr props) {
+  if (!name || name.getValue().empty()) {
+    return emitError() << "site must have a non-empty name";
+  }
+  if (capacity == 0) {
+    return emitError() << "site @" << name.getValue() << " must have a capacity of at least 1";
+  }
+  // A fixed site models a single qubit, such as a superconducting transmon or
+  // an SLM trap, rather than a container; nothing can enter or leave it.
+  if (kind == SiteKind::Fixed && capacity != 1) {
+    return emitError() << "fixed site @" << name.getValue() << " must have capacity 1, but has " << capacity;
+  }
+  // A site cannot host an operation on more qubits than it can hold.
+  if (maxFacetRank && *maxFacetRank > capacity) {
+    return emitError() << "site @" << name.getValue() << " declares maxFacetRank = " << *maxFacetRank
+                       << " but holds at most " << capacity << " qubit(s)";
+  }
+  // A position has two or three components. Accepting any other length and
+  // reading the first two would mask a typo in the description.
+  if (coords && (coords.size() < 2 || coords.size() > 3)) {
+    return emitError() << "site @" << name.getValue() << " declares " << coords.size()
+                       << " coordinate(s); a position is 2 or 3 numbers";
+  }
+  // A malformed turn entry would silently forbid every turn through the
+  // junction, which is harder to diagnose than a rejected description.
+  if (props) {
+    if (const auto turns = props.getAs<ArrayAttr>("turns")) {
+      for (const auto entry : turns) {
+        const auto name_ = llvm::dyn_cast<StringAttr>(entry);
+        if (!name_ || !name_.getValue().contains('>')) {
+          return emitError() << "site @" << name.getValue()
+                             << " has a malformed `turns` entry; each is \"<incoming-id>><outgoing-id>\"";
+        }
+      }
+    }
+  }
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// HyperedgeAttr
+//===----------------------------------------------------------------------===//
+
+llvm::StringRef HyperedgeAttr::getId() const {
+  if (const auto props = getProps()) {
+    if (const auto id = props.getAs<StringAttr>("id")) {
+      return id.getValue();
+    }
+  }
+  return {};
+}
+
+std::optional<ChainEnd> HyperedgeAttr::getEndAt(const llvm::StringRef site) const {
+  const auto props = getProps();
+  if (!props) {
+    return std::nullopt;
+  }
+  const auto ends = props.getAs<ArrayAttr>("ends");
+  if (!ends) {
+    return std::nullopt;
+  }
+  for (const auto& [index, member] : llvm::enumerate(getSites())) {
+    if (member.getValue() != site) {
+      continue;
+    }
+    if (index >= ends.size()) {
+      return std::nullopt;
+    }
+    const auto name = llvm::dyn_cast<StringAttr>(ends[index]);
+    return name ? symbolizeChainEnd(name.getValue()) : std::nullopt;
+  }
+  return std::nullopt;
+}
+
+bool HyperedgeAttr::isPersistent() const {
+  const auto props = getProps();
+  if (!props) {
+    return false;
+  }
+  const auto flag = props.getAs<BoolAttr>("persistent");
+  return flag && flag.getValue();
+}
+
+double HyperedgeAttr::getLatencyUs() const {
+  if (const auto props = getProps()) {
+    if (const auto latency = props.getAs<FloatAttr>("latency_us")) {
+      return latency.getValueAsDouble();
+    }
+    if (const auto latency = props.getAs<IntegerAttr>("latency_us")) {
+      return static_cast<double>(latency.getInt());
+    }
+  }
+  return 0.0;
+}
+
+bool HyperedgeAttr::hasFlag(const llvm::StringRef key) const {
+  const auto props = getProps();
+  if (!props) {
+    return false;
+  }
+  const auto flag = props.getAs<BoolAttr>(key);
+  return flag && flag.getValue();
+}
+
+std::optional<int64_t> HyperedgeAttr::getIntProp(const llvm::StringRef key) const {
+  if (const auto props = getProps()) {
+    if (const auto value = props.getAs<IntegerAttr>(key)) {
+      return value.getInt();
+    }
+  }
+  return std::nullopt;
+}
+
+bool HyperedgeAttr::contains(const llvm::StringRef site) const {
+  return llvm::any_of(getSites(), [&](const FlatSymbolRefAttr name) { return name.getValue() == site; });
+}
+
+LogicalResult HyperedgeAttr::verify(const llvm::function_ref<InFlightDiagnostic()> emitError, const EdgeKind kind,
+                                    const llvm::ArrayRef<FlatSymbolRefAttr> sites, const DictionaryAttr props) {
+  if (sites.empty()) {
+    return emitError() << "hyperedge must be incident to at least one site";
+  }
+
+  llvm::StringSet<> seen;
+  for (const auto site : sites) {
+    if (!site || site.getValue().empty()) {
+      return emitError() << "hyperedge site names must be non-empty";
+    }
+    if (!seen.insert(site.getValue()).second) {
+      return emitError() << "hyperedge lists site @" << site.getValue() << " twice";
+    }
+  }
+
+  // Displacement is a binary relation: a shuttle moves a group from one site to
+  // another. There is no physical operation moving an ion out of {A, B, C}, and
+  // a junction is a site of high degree rather than an edge of high arity.
+  if (kind == EdgeKind::Transport && sites.size() != 2) {
+    return emitError() << "transport edge must have rank 2, but is incident to " << sites.size() << " sites";
+  }
+
+  // An entanglement resource joins at least two parties; a Bell pair is rank 2
+  // and a GHZ resource is rank >= 3.
+  if (kind == EdgeKind::Link && sites.size() < 2) {
+    return emitError() << "link edge must have rank at least 2, but is incident to " << sites.size() << " site";
+  }
+
+  // A rule addresses an edge by name, so every kind a rule can act on requires
+  // one. Control edges are exempt, since no rule fires on them and only the
+  // scheduler reads them.
+  if (kind != EdgeKind::Control) {
+    const auto id = props ? props.getAs<StringAttr>("id") : StringAttr{};
+    if (!id || id.getValue().empty()) {
+      return emitError() << stringifyEdgeKind(kind)
+                         << " edge must carry a non-empty string `id` property, which is how a rewrite rule "
+                            "addresses it";
+    }
+  }
+
+  // A segment joins a trap at one of its ends, and which end determines what
+  // can leave. Declaring the ends is optional, but a length mismatch would
+  // silently associate the wrong end with the wrong trap.
+  if (const auto ends = props ? props.getAs<ArrayAttr>("ends") : ArrayAttr{}) {
+    if (kind != EdgeKind::Transport) {
+      return emitError() << "`ends` is only meaningful on a transport edge: it names which end of each trap the "
+                            "segment meets";
+    }
+    if (ends.size() != sites.size()) {
+      return emitError() << "`ends` has " << ends.size() << " entr" << (ends.size() == 1 ? "y" : "ies")
+                         << " but the edge is incident to " << sites.size() << " site(s); give one end per endpoint";
+    }
+    for (const auto entry : ends) {
+      const auto name = llvm::dyn_cast<StringAttr>(entry);
+      if (!name || !symbolizeChainEnd(name.getValue())) {
+        return emitError() << "`ends` entries must be \"head\" or \"tail\"";
+      }
+    }
+  }
+
+  // Whether a link is consumed by use determines whether the edge contributes a
+  // facet to K on its own or only once `qcc.link.generate` has heralded one over
+  // it. A permanent coupler and a heralded Bell pair are both link edges with
+  // different semantics, so the description must state which applies rather than
+  // rely on a default.
+  if (kind == EdgeKind::Link && (!props || !props.getAs<BoolAttr>("persistent"))) {
+    return emitError() << "link edge must declare `persistent`: true for a coupler that is never consumed, false "
+                          "for a resource spent by use";
+  }
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// SubstrateAttr
+//===----------------------------------------------------------------------===//
+
+std::optional<unsigned> SubstrateAttr::findSite(const llvm::StringRef name) const {
+  for (const auto& [index, site] : llvm::enumerate(getSites())) {
+    if (site.getSymName() == name) {
+      return static_cast<unsigned>(index);
+    }
+  }
+  return std::nullopt;
+}
+
+SiteAttr SubstrateAttr::lookupSite(const llvm::StringRef name) const {
+  const auto index = findSite(name);
+  return index ? getSites()[*index] : SiteAttr{};
+}
+
+HyperedgeAttr SubstrateAttr::lookupEdge(const EdgeKind kind, const llvm::StringRef id) const {
+  for (const auto edge : getEdges()) {
+    if (edge.getKind() == kind && edge.getId() == id) {
+      return edge;
+    }
+  }
+  return {};
+}
+
+llvm::SmallVector<HyperedgeAttr> SubstrateAttr::getEdgesOfKind(const EdgeKind kind) const {
+  llvm::SmallVector<HyperedgeAttr> result;
+  for (const auto edge : getEdges()) {
+    if (edge.getKind() == kind) {
+      result.push_back(edge);
+    }
+  }
+  return result;
+}
+
+Attribute SubstrateAttr::parse(AsmParser& parser, Type /*type*/) {
+  llvm::SmallVector<SiteAttr> sites;
+  llvm::SmallVector<HyperedgeAttr> edges;
+
+  const auto parseSite = [&]() -> ParseResult {
+    SiteAttr site;
+    if (parser.parseAttribute(site)) {
+      return failure();
+    }
+    sites.push_back(site);
+    return success();
+  };
+  const auto parseEdge = [&]() -> ParseResult {
+    HyperedgeAttr edge;
+    if (parser.parseAttribute(edge)) {
+      return failure();
+    }
+    edges.push_back(edge);
+    return success();
+  };
+
+  if (parser.parseLess() || parser.parseKeyword("sites") || parser.parseEqual() ||
+      parser.parseCommaSeparatedList(AsmParser::Delimiter::Square, parseSite) || parser.parseComma() ||
+      parser.parseKeyword("edges") || parser.parseEqual() ||
+      parser.parseCommaSeparatedList(AsmParser::Delimiter::Square, parseEdge) || parser.parseGreater()) {
+    return {};
+  }
+
+  return parser.getChecked<SubstrateAttr>(parser.getContext(), sites, edges);
+}
+
+void SubstrateAttr::print(AsmPrinter& printer) const {
+  printer << "<sites = [";
+  llvm::interleaveComma(getSites(), printer);
+  printer << "], edges = [";
+  llvm::interleaveComma(getEdges(), printer);
+  printer << "]>";
+}
+
+LogicalResult SubstrateAttr::verify(const llvm::function_ref<InFlightDiagnostic()> emitError,
+                                    const llvm::ArrayRef<SiteAttr> sites, const llvm::ArrayRef<HyperedgeAttr> edges) {
+  llvm::StringSet<> declared;
+  for (const auto site : sites) {
+    if (!declared.insert(site.getSymName()).second) {
+      return emitError() << "substrate declares site @" << site.getSymName() << " twice";
+    }
+  }
+
+  llvm::StringSet<> edgeIds;
+  for (const auto edge : edges) {
+    for (const auto name : edge.getSites()) {
+      if (!declared.contains(name.getValue())) {
+        return emitError() << "edge refers to undeclared site @" << name.getValue();
+      }
+    }
+
+    // Ids are unique across the whole substrate rather than per kind, so a
+    // rule's `via` names exactly one edge irrespective of its kind.
+    if (const auto id = edge.getId(); !id.empty() && !edgeIds.insert(id).second) {
+      return emitError() << "substrate declares two edges with id '" << id << "'";
+    }
+
+    if (edge.getKind() != EdgeKind::Transport) {
+      continue;
+    }
+    // Nothing enters or leaves a fixed site. Permitting an incident transport
+    // edge would let a superconducting substrate express shuttling.
+    for (const auto name : edge.getSites()) {
+      const auto* site = llvm::find_if(sites, [&](const SiteAttr s) { return s.getSymName() == name.getValue(); });
+      if (site != sites.end() && site->getKind() == SiteKind::Fixed) {
+        return emitError() << "transport edge '" << edge.getId() << "' touches fixed site @" << name.getValue()
+                           << "; a fixed site cannot be entered or left";
+      }
+    }
+  }
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// DeviceAttr
+//===----------------------------------------------------------------------===//
+
+bool DeviceAttr::isStatic() const {
+  const auto substrate = getSubstrate();
+  if (!substrate.getEdgesOfKind(EdgeKind::Transport).empty() || !substrate.getEdgesOfKind(EdgeKind::Rigid).empty()) {
+    return false;
+  }
+  // A consumable link makes the device dynamic even though nothing moves, since
+  // heralding and consuming one both rewrite the configuration.
+  return llvm::all_of(substrate.getEdgesOfKind(EdgeKind::Link),
+                      [](const HyperedgeAttr edge) { return edge.isPersistent(); });
+}
+
+Representation DeviceAttr::getRepresentation() const {
+  // An empty rule set leaves nothing to represent along the chain: every use of
+  // a configuration resolves to the one `qcc.config.init` established.
+  if (isStatic()) {
+    return Representation::Static;
+  }
+  // Partitioning facets over ordered words are exactly an ordered partition.
+  if (getPartitioning() && getFacetOrdering() == FacetOrdering::Linear) {
+    return Representation::OrderedPartition;
+  }
+  // One qubit per site makes the placement an injection, and the facets then
+  // come from the substrate's link edges rather than from co-location.
+  const auto sites = getSubstrate().getSites();
+  if (!getPartitioning() && llvm::all_of(sites, [](const SiteAttr site) { return site.getCapacity() <= 1; })) {
+    return Representation::Injection;
+  }
+  return Representation::ExplicitIncidence;
+}
+
+LogicalResult DeviceAttr::verify(const llvm::function_ref<InFlightDiagnostic()> emitError,
+                                 const SubstrateAttr substrate, const uint64_t maxFacetRank, bool /*downwardClosed*/,
+                                 const bool partitioning, const FacetOrdering facetOrdering) {
+  if (!substrate) {
+    return emitError() << "device must carry a substrate";
+  }
+  if (maxFacetRank < 2) {
+    return emitError() << "device maxFacetRank must be at least 2, but is " << maxFacetRank
+                       << "; a device that cannot entangle two qubits has nothing to route";
+  }
+  // `partitioning` asserts that the facets of K form a partition of the qubits,
+  // which is what allows the hypergraph to collapse to an ordered partition
+  // without loss of information. A link edge contradicts that by construction:
+  // it forms a facet from qubits drawn from several sites, and that facet
+  // overlaps every group it drew from. Superconducting couplers, Rydberg
+  // blockade discs and photonic interconnects are all link edges, which is why
+  // those devices are non-partitioning.
+  //
+  // `facetOrdering = linear` together with `partitioning = false` is not
+  // checked, because it is not an error: it describes a modular ion machine
+  // whose chains are ordered words and whose photonic links lay facets across
+  // them.
+  if (const auto links = substrate.getEdgesOfKind(EdgeKind::Link); partitioning && !links.empty()) {
+    return emitError() << "partitioning = true is inconsistent with " << links.size()
+                       << " link edge(s): a link forms a facet from qubits at several sites, which overlaps the "
+                          "groups it draws from, so the facets are not a partition";
+  }
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// PlacementAttr
+//===----------------------------------------------------------------------===//
+
+Attribute PlacementAttr::parse(AsmParser& parser, Type /*type*/) {
+  if (parser.parseLess()) {
+    return {};
+  }
+
+  llvm::SmallVector<FlatSymbolRefAttr> sites;
+  llvm::SmallVector<ArrayAttr> groups;
+
+  if (succeeded(parser.parseOptionalGreater())) {
+    return parser.getChecked<PlacementAttr>(parser.getContext(), sites, groups);
+  }
+
+  const auto parseSite = [&]() -> ParseResult {
+    FlatSymbolRefAttr name;
+    if (parser.parseAttribute(name) || parser.parseEqual()) {
+      return failure();
+    }
+
+    llvm::SmallVector<Attribute> words;
+    const auto parseWord = [&]() -> ParseResult {
+      llvm::SmallVector<int64_t> word;
+      const auto parseQubit = [&]() -> ParseResult {
+        int64_t qubit = 0;
+        if (parser.parseInteger(qubit)) {
+          return failure();
+        }
+        word.push_back(qubit);
+        return success();
+      };
+      if (parser.parseCommaSeparatedList(AsmParser::Delimiter::Square, parseQubit)) {
+        return failure();
+      }
+      words.push_back(DenseI64ArrayAttr::get(parser.getContext(), word));
+      return success();
+    };
+
+    if (parser.parseCommaSeparatedList(AsmParser::Delimiter::Square, parseWord)) {
+      return failure();
+    }
+
+    sites.push_back(name);
+    groups.push_back(ArrayAttr::get(parser.getContext(), words));
+    return success();
+  };
+
+  if (parser.parseCommaSeparatedList(AsmParser::Delimiter::None, parseSite) || parser.parseGreater()) {
+    return {};
+  }
+
+  return parser.getChecked<PlacementAttr>(parser.getContext(), sites, groups);
+}
+
+void PlacementAttr::print(AsmPrinter& printer) const {
+  printer << "<";
+  llvm::interleaveComma(llvm::zip_equal(getSites(), getGroups()), printer, [&](const auto& entry) {
+    const auto& [site, words] = entry;
+    printer << site << " = [";
+    llvm::interleaveComma(words, printer, [&](const Attribute word) {
+      printer << "[";
+      llvm::interleaveComma(llvm::cast<DenseI64ArrayAttr>(word).asArrayRef(), printer,
+                            [&](const int64_t qubit) { printer << qubit; });
+      printer << "]";
+    });
+    printer << "]";
+  });
+  printer << ">";
+}
+
+LogicalResult PlacementAttr::verify(const llvm::function_ref<InFlightDiagnostic()> emitError,
+                                    const llvm::ArrayRef<FlatSymbolRefAttr> sites,
+                                    const llvm::ArrayRef<ArrayAttr> groups) {
+  if (sites.size() != groups.size()) {
+    return emitError() << "placement has " << sites.size() << " sites but " << groups.size() << " group lists";
+  }
+
+  llvm::StringSet<> seenSites;
+  llvm::DenseSet<int64_t> seenQubits;
+  for (const auto& [site, words] : llvm::zip_equal(sites, groups)) {
+    if (!site || site.getValue().empty()) {
+      return emitError() << "placement site names must be non-empty";
+    }
+    if (!seenSites.insert(site.getValue()).second) {
+      return emitError() << "placement mentions site @" << site.getValue() << " twice";
+    }
+
+    for (const auto word : words) {
+      const auto group = llvm::dyn_cast<DenseI64ArrayAttr>(word);
+      if (!group) {
+        return emitError() << "each group must be an array of qubit indices";
+      }
+      if (group.empty()) {
+        return emitError() << "site @" << site.getValue()
+                           << " holds an empty group; an empty potential well is not a group, so drop it";
+      }
+      for (const int64_t qubit : group.asArrayRef()) {
+        if (qubit < 0) {
+          return emitError() << "qubit index must be non-negative, but got " << qubit;
+        }
+        // A placement is a partial injection: a qubit is in at most one place.
+        if (!seenQubits.insert(qubit).second) {
+          return emitError() << "qubit " << qubit << " is placed more than once";
+        }
+      }
+    }
+  }
+
+  return success();
+}
+
+Configuration PlacementAttr::toConfiguration() const {
+  Configuration config;
+  for (const auto& [site, words] : llvm::zip_equal(getSites(), getGroups())) {
+    SiteContents groups;
+    for (const auto word : words) {
+      const auto group = llvm::cast<DenseI64ArrayAttr>(word).asArrayRef();
+      groups.emplace_back(group.begin(), group.end());
+    }
+    config.sites.push_back({site.getValue().str(), std::move(groups)});
+  }
+  return config;
+}
+
+PlacementAttr PlacementAttr::get(MLIRContext* ctx, const Configuration& config) {
+  llvm::SmallVector<FlatSymbolRefAttr> sites;
+  llvm::SmallVector<ArrayAttr> groups;
+  for (const auto& site : config.sites) {
+    sites.push_back(FlatSymbolRefAttr::get(ctx, site.name));
+    llvm::SmallVector<Attribute> words;
+    words.reserve(site.groups.size());
+    for (const auto& word : site.groups) {
+      words.push_back(DenseI64ArrayAttr::get(ctx, word));
+    }
+    groups.push_back(ArrayAttr::get(ctx, words));
+  }
+  return PlacementAttr::get(ctx, sites, groups);
+}

--- a/mlir/lib/Dialect/QCC/IR/QCCOps.cpp
+++ b/mlir/lib/Dialect/QCC/IR/QCCOps.cpp
@@ -1,0 +1,794 @@
+// ===----------------------------------------------------------------------===//
+//
+// Part of the FullStaQD Project, under the Apache License v2.0 with LLVM
+// Exceptions.
+// See <repo-root>/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// ===----------------------------------------------------------------------===//
+
+#include "qcc/Dialect/QCC/IR/QCC.h"
+
+#include "mlir/IR/Value.h"
+#include "mlir/Support/LLVM.h"
+
+#include <cstdint>
+#include <llvm/ADT/DenseSet.h>
+#include <llvm/ADT/STLExtras.h>
+#include <llvm/ADT/SmallVector.h>
+#include <llvm/ADT/StringRef.h>
+#include <llvm/ADT/StringSet.h>
+#include <llvm/Support/Casting.h>
+#include <llvm/Support/raw_ostream.h>
+#include <string>
+#include <utility>
+
+using namespace mlir;
+using namespace qcc::conn;
+
+#include "qcc/Dialect/QCC/IR/QCCInterfaces.cpp.inc"
+
+#define GET_OP_CLASSES
+#include "qcc/Dialect/QCC/IR/QCCOps.cpp.inc"
+
+namespace qcc::conn {
+
+namespace {
+
+/// The substrate `op`'s configuration operand is typed over.
+SubstrateAttr getSubstrateOf(Operation* op) {
+  return llvm::cast<ConfigType>(op->getResult(0).getType()).getDevice().getSubstrate();
+}
+
+/// Static check shared by every rule that names a site: the substrate must
+/// declare it. Checking here catches typos at verification time rather than
+/// leaving them to the analysis, which only observes the sites a placement
+/// happens to mention.
+LogicalResult verifyDeclaredSite(Operation* op, const FlatSymbolRefAttr site, const llvm::StringRef what) {
+  if (!getSubstrateOf(op).lookupSite(site.getValue())) {
+    return op->emitOpError() << "substrate declares no " << what << " site @" << site.getValue();
+  }
+  return success();
+}
+
+/// Static check shared by the chain rules. All of them rewrite a chain as an
+/// ordered word: `split` detaches at an end, `merge` concatenates and `reorder`
+/// permutes. The property that admits them is therefore `facetOrdering =
+/// linear`.
+///
+/// This is not a check on `partitioning`. A modular ion machine has ordered
+/// chains and non-partitioning K simultaneously, since its chains are words and
+/// its photonic links lay facets across them; gating these rules on
+/// `partitioning` would withdraw the whole rule set from any machine with an
+/// optical interconnect.
+LogicalResult verifyChainSite(Operation* op, const DeviceAttr device, const llvm::StringRef site,
+                              const llvm::StringRef opName) {
+  const auto declared = device.getSubstrate().lookupSite(site);
+  const auto ordering =
+      declared ? declared.getEffectiveFacetOrdering(device.getFacetOrdering()) : device.getFacetOrdering();
+  if (ordering != FacetOrdering::Linear) {
+    return op->emitOpError() << opName << " requires facetOrdering = linear, but @" << site << " is "
+                             << stringifyFacetOrdering(ordering)
+                             << ": this rule rewrites a chain as an ordered word, and a facet carrying no such "
+                                "order has no ends to detach at and no order to permute";
+  }
+  return success();
+}
+
+/// Locate a chain in a configuration, reporting where it went missing.
+FailureOr<std::pair<SiteContents*, unsigned>> findChain(Operation* op, Configuration& config,
+                                                        const llvm::StringRef site, const uint64_t chain) {
+  auto* contents = config.lookup(site);
+  if (contents == nullptr) {
+    return op->emitOpError() << "the configuration reaching this operation places nothing at site @" << site;
+  }
+  if (chain >= contents->size()) {
+    return op->emitOpError() << "site @" << site << " holds " << contents->size() << " chain(s), so there is no "
+                             << "chain " << chain << " to act on here";
+  }
+  return std::pair{contents, static_cast<unsigned>(chain)};
+}
+
+} // namespace
+
+} // namespace qcc::conn
+
+//===----------------------------------------------------------------------===//
+// ConfigInitOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult ConfigInitOp::verify() {
+  const auto device = getDeviceAttr();
+  const auto substrate = device.getSubstrate();
+  const auto placement = getPlacement();
+  const auto config = placement.toConfiguration();
+
+  for (const auto& placed : config.sites) {
+    const auto site = substrate.lookupSite(placed.name);
+    if (!site) {
+      return emitOpError() << "places qubits at @" << placed.name << ", which the substrate does not declare";
+    }
+
+    const auto load = config.getLoad(placed.name);
+    if (load > site.getCapacity()) {
+      return emitOpError() << "places " << load << " qubits at @" << placed.name << ", exceeding its capacity of "
+                           << site.getCapacity();
+    }
+
+    // Implied by capacity 1, but reported separately because holding two groups
+    // is a more precise diagnosis than exceeding capacity.
+    if (site.getKind() == SiteKind::Fixed && placed.groups.size() > 1) {
+      return emitOpError() << "fixed site @" << placed.name << " holds " << placed.groups.size()
+                           << " groups; a fixed site holds exactly one qubit";
+    }
+  }
+
+  return success();
+}
+
+//===----------------------------------------------------------------------===//
+// IonSplitOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult IonSplitOp::verify() {
+  // The `end` attribute exists because only the ends of a chain can be
+  // detached. An unordered device has no chain ends, so the operation is
+  // undefined there rather than unrestricted.
+  if (failed(verifyChainSite(*this, getDeviceAttr(), getSite(), "ion.split"))) {
+    return failure();
+  }
+  return verifyDeclaredSite(*this, getSiteAttr(), "trap or junction");
+}
+
+FailureOr<Configuration> IonSplitOp::applyRule(const Configuration& in) {
+  Configuration out = in;
+  const auto located = findChain(*this, out, getSite(), getChain());
+  if (failed(located)) {
+    return failure();
+  }
+  auto* contents = located->first;
+  const auto index = located->second;
+
+  const Word word = (*contents)[index];
+  const auto count = static_cast<size_t>(getCount());
+  if (count >= word.size()) {
+    return emitOpError() << "cannot detach " << count << " ion(s) from a chain of length " << word.size()
+                         << "; a split must leave a non-empty remainder on both sides";
+  }
+
+  const auto atHead = getEnd() == ChainEnd::Head;
+  const Word detached = atHead ? Word(word.begin(), word.begin() + count) : Word(word.end() - count, word.end());
+  const Word remainder = atHead ? Word(word.begin() + count, word.end()) : Word(word.begin(), word.end() - count);
+
+  // The detached part remains on the side it came from: a split opens a second
+  // potential well next to the first rather than rearranging the segment.
+  (*contents)[index] = atHead ? detached : remainder;
+  contents->insert(contents->begin() + index + 1, atHead ? remainder : detached);
+
+  return out;
+}
+
+//===----------------------------------------------------------------------===//
+// IonMergeOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult IonMergeOp::verify() {
+  if (failed(verifyChainSite(*this, getDeviceAttr(), getSite(), "ion.merge"))) {
+    return failure();
+  }
+  if (getDst() == getSrc()) {
+    return emitOpError() << "cannot merge chain " << getDst() << " into itself";
+  }
+  return verifyDeclaredSite(*this, getSiteAttr(), "trap or junction");
+}
+
+FailureOr<Configuration> IonMergeOp::applyRule(const Configuration& in) {
+  Configuration out = in;
+  const auto dstLocated = findChain(*this, out, getSite(), getDst());
+  if (failed(dstLocated)) {
+    return failure();
+  }
+  const auto srcLocated = findChain(*this, out, getSite(), getSrc());
+  if (failed(srcLocated)) {
+    return failure();
+  }
+
+  auto* contents = dstLocated->first;
+  const auto dst = dstLocated->second;
+  const auto src = srcLocated->second;
+
+  const Word source = (*contents)[src];
+  Word merged;
+  if (getAt() == ChainEnd::Head) {
+    // Prepending leaves the source's ions at the head, where they remain
+    // detachable without a reorder.
+    merged.append(source.begin(), source.end());
+    merged.append((*contents)[dst].begin(), (*contents)[dst].end());
+  } else {
+    merged.append((*contents)[dst].begin(), (*contents)[dst].end());
+    merged.append(source.begin(), source.end());
+  }
+
+  (*contents)[dst] = std::move(merged);
+  contents->erase(contents->begin() + src);
+
+  return out;
+}
+
+//===----------------------------------------------------------------------===//
+// IonTransportOp
+//===----------------------------------------------------------------------===//
+
+HyperedgeAttr IonTransportOp::getEdge() { return getSubstrateOf(*this).lookupTransportEdge(getVia()); }
+
+llvm::StringRef IonTransportOp::getDestination() {
+  const auto edge = getEdge();
+  if (!edge) {
+    return {};
+  }
+  for (const auto site : edge.getSites()) {
+    if (site.getValue() != getFrom()) {
+      return site.getValue();
+    }
+  }
+  return {};
+}
+
+LogicalResult IonTransportOp::verify() {
+  if (failed(verifyDeclaredSite(*this, getFromAttr(), "source"))) {
+    return failure();
+  }
+
+  const auto edge = getEdge();
+  if (!edge) {
+    return emitOpError() << "substrate declares no transport edge with id '" << getVia() << "'";
+  }
+  if (!edge.contains(getFrom())) {
+    return emitOpError() << "transport edge '" << getVia() << "' is not incident to @" << getFrom()
+                         << ", so a chain cannot leave that site along it";
+  }
+
+  // A segment declared `bidirectional = false` runs from its first incident
+  // site to its second. Absent the property, both directions are allowed.
+  const auto bidirectional = edge.getProps().getAs<BoolAttr>("bidirectional");
+  if (bidirectional && !bidirectional.getValue() && edge.getSites().front().getValue() != getFrom()) {
+    return emitOpError() << "transport edge '" << getVia() << "' is unidirectional from @"
+                         << edge.getSites().front().getValue() << " to @" << edge.getSites().back().getValue()
+                         << ", but this operation traverses it the other way";
+  }
+
+  return success();
+}
+
+FailureOr<Configuration> IonTransportOp::applyRule(const Configuration& in) {
+  Configuration out = in;
+  const auto located = findChain(*this, out, getFrom(), getChain());
+  if (failed(located)) {
+    return failure();
+  }
+  auto* source = located->first;
+  const auto index = located->second;
+  const Word word = (*source)[index];
+
+  const auto edge = getEdge();
+
+  // A segment joins a trap at one end, so only the chain at that end can leave;
+  // anything further in would have to pass through the chains in front of it.
+  // The chain list is maintained in spatial order, since a split leaves the
+  // detached part on the side it came from, so the reachable chain is either the
+  // first or the last index.
+  if (const auto door = edge.getEndAt(getFrom())) {
+    const auto atDoor = *door == ChainEnd::Head ? 0U : static_cast<unsigned>(source->size() - 1);
+    if (index != atDoor) {
+      return emitOpError() << "chain " << index << " is not at the door: segment '" << getVia() << "' meets @"
+                           << getFrom() << " at its " << stringifyChainEnd(*door) << " end, so only chain " << atDoor
+                           << " can leave; the " << (index > atDoor ? index - atDoor : atDoor - index)
+                           << " chain(s) in between would have to be moved first";
+    }
+  }
+
+  if (const auto maxLen = edge.getIntProp("max_chain_len"); maxLen && word.size() > static_cast<size_t>(*maxLen)) {
+    return emitOpError() << "chain of length " << word.size() << " exceeds the max_chain_len of " << *maxLen
+                         << " declared by segment '" << getVia() << "'";
+  }
+
+  const auto destination = getDestination();
+  const auto destSite = getSubstrateOf(*this).lookupSite(destination);
+  const auto arriving = out.getLoad(destination) + word.size();
+  if (arriving > destSite.getCapacity()) {
+    return emitOpError() << "would place " << arriving << " qubits at @" << destination
+                         << ", exceeding its capacity of " << destSite.getCapacity();
+  }
+
+  source->erase(source->begin() + index);
+
+  // The arrival lands at the end it entered through rather than at an arbitrary
+  // position, so that it can leave again along the segment it arrived on.
+  const auto arrivalDoor = edge.getEndAt(destination);
+  const bool landsAtHead = arrivalDoor && *arrivalDoor == ChainEnd::Head;
+
+  auto& arrival = out.lookupOrAdd(destination);
+  if (landsAtHead) {
+    arrival.insert(arrival.begin(), word);
+  } else {
+    arrival.push_back(word);
+  }
+
+  return out;
+}
+
+double IonTransportOp::getLatencyUs() {
+  const auto edge = getEdge();
+  return edge ? edge.getLatencyUs() : 0.0;
+}
+
+//===----------------------------------------------------------------------===//
+// IonReorderOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult IonReorderOp::verify() {
+  if (failed(verifyChainSite(*this, getDeviceAttr(), getSite(), "ion.reorder"))) {
+    return failure();
+  }
+  if (failed(verifyDeclaredSite(*this, getSiteAttr(), "trap or junction"))) {
+    return failure();
+  }
+
+  const auto permutation = getPermutation();
+  if (permutation.empty()) {
+    return emitOpError() << "permutation must not be empty";
+  }
+
+  llvm::DenseSet<int64_t> seen;
+  for (const int64_t position : permutation) {
+    if (position < 0 || static_cast<size_t>(position) >= permutation.size()) {
+      return emitOpError() << "permutation entry " << position << " is out of range for a chain of length "
+                           << permutation.size();
+    }
+    if (!seen.insert(position).second) {
+      return emitOpError() << "permutation names position " << position << " twice";
+    }
+  }
+
+  return success();
+}
+
+FailureOr<Configuration> IonReorderOp::applyRule(const Configuration& in) {
+  Configuration out = in;
+  const auto located = findChain(*this, out, getSite(), getChain());
+  if (failed(located)) {
+    return failure();
+  }
+  auto& word = (*located->first)[located->second];
+
+  const auto permutation = getPermutation();
+  if (word.size() != permutation.size()) {
+    return emitOpError() << "permutation has " << permutation.size() << " entries but chain " << getChain() << " at @"
+                         << getSite() << " holds " << word.size() << " ions";
+  }
+
+  Word reordered;
+  reordered.reserve(word.size());
+  for (const int64_t from : permutation) {
+    reordered.push_back(word[static_cast<size_t>(from)]);
+  }
+  word = std::move(reordered);
+
+  return out;
+}
+
+//===----------------------------------------------------------------------===//
+// AtomAodMoveOp
+//===----------------------------------------------------------------------===//
+
+HyperedgeAttr AtomAodMoveOp::getEdge() { return getSubstrateOf(*this).lookupEdge(EdgeKind::Rigid, getVia()); }
+
+LogicalResult AtomAodMoveOp::verify() {
+  const auto substrate = getSubstrateOf(*this);
+
+  const auto edge = getEdge();
+  if (!edge) {
+    return emitOpError() << "substrate declares no rigid edge with id '" << getVia() << "'";
+  }
+
+  const auto sources = edge.getSites();
+  const auto destinations = getTo().getValue();
+  if (sources.size() != destinations.size()) {
+    return emitOpError() << "rigid edge '" << getVia() << "' carries " << sources.size() << " site(s), but "
+                         << destinations.size() << " destination(s) were given; the whole axis moves as a unit";
+  }
+
+  llvm::StringSet<> seen;
+  llvm::SmallVector<unsigned> destinationOrder;
+  for (const auto destination : destinations) {
+    const auto name = llvm::cast<FlatSymbolRefAttr>(destination).getValue();
+    const auto index = substrate.findSite(name);
+    if (!index) {
+      return emitOpError() << "substrate declares no site @" << name;
+    }
+    if (!seen.insert(name).second) {
+      return emitOpError() << "two atoms on '" << getVia() << "' would land in @" << name;
+    }
+    destinationOrder.push_back(*index);
+  }
+
+  // AOD rows cannot pass through one another, so the axis must arrive in the
+  // order it left in. The substrate's declaration order is read as the geometric
+  // order along the axis.
+  llvm::SmallVector<unsigned> sourceOrder;
+  for (const auto source : sources) {
+    sourceOrder.push_back(*substrate.findSite(source.getValue()));
+  }
+  for (size_t i = 1; i < sourceOrder.size(); ++i) {
+    const bool sourceAscends = sourceOrder[i] > sourceOrder[i - 1];
+    const bool destinationAscends = destinationOrder[i] > destinationOrder[i - 1];
+    if (sourceAscends != destinationAscends) {
+      return emitOpError() << "move is crossing: @" << sources[i - 1].getValue() << " and @" << sources[i].getValue()
+                           << " would swap order on the way to @"
+                           << llvm::cast<FlatSymbolRefAttr>(destinations[i - 1]).getValue() << " and @"
+                           << llvm::cast<FlatSymbolRefAttr>(destinations[i]).getValue()
+                           << "; AOD traps cannot pass through one another";
+    }
+  }
+
+  return success();
+}
+
+FailureOr<Configuration> AtomAodMoveOp::applyRule(const Configuration& in) {
+  Configuration out = in;
+  const auto edge = getEdge();
+  const auto destinations = getTo().getValue();
+
+  // Every atom on the axis lifts simultaneously, so all sources are read and
+  // cleared before any destination is written; otherwise an axis sliding by one
+  // site would collide with itself.
+  llvm::SmallVector<SiteContents> inFlight;
+  for (const auto source : edge.getSites()) {
+    auto* contents = out.lookup(source.getValue());
+    if (contents == nullptr) {
+      inFlight.emplace_back();
+      continue;
+    }
+    inFlight.push_back(*contents);
+    contents->clear();
+  }
+
+  const auto substrate = getSubstrateOf(*this);
+  for (const auto& [destination, arriving] : llvm::zip_equal(destinations, inFlight)) {
+    if (arriving.empty()) {
+      continue;
+    }
+    const auto name = llvm::cast<FlatSymbolRefAttr>(destination).getValue();
+
+    uint64_t landing = 0;
+    for (const auto& word : arriving) {
+      landing += word.size();
+    }
+    const auto load = out.getLoad(name) + landing;
+    if (const auto capacity = substrate.lookupSite(name).getCapacity(); load > capacity) {
+      return emitOpError() << "would place " << load << " atoms at @" << name << ", exceeding its capacity of "
+                           << capacity;
+    }
+
+    llvm::append_range(out.lookupOrAdd(name), arriving);
+  }
+
+  return out;
+}
+
+double AtomAodMoveOp::getLatencyUs() {
+  const auto edge = getEdge();
+  return edge ? edge.getLatencyUs() : 0.0;
+}
+
+//===----------------------------------------------------------------------===//
+// AtomSlmTransferOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult AtomSlmTransferOp::verify() {
+  if (failed(verifyDeclaredSite(*this, getFromAttr(), "source")) ||
+      failed(verifyDeclaredSite(*this, getToAttr(), "destination"))) {
+    return failure();
+  }
+  if (getFrom() == getTo()) {
+    return emitOpError() << "source and destination are the same site @" << getFrom();
+  }
+
+  // The tweezer can only carry an atom along an axis the atom is on, so the
+  // substrate determines how far a handoff can reach.
+  const auto substrate = getSubstrateOf(*this);
+  for (const auto edge : substrate.getEdgesOfKind(EdgeKind::Rigid)) {
+    if (edge.contains(getFrom()) && edge.contains(getTo())) {
+      return success();
+    }
+  }
+  return emitOpError() << "no rigid edge is incident to both @" << getFrom() << " and @" << getTo()
+                       << "; a tweezer can only carry an atom along an axis that reaches both traps";
+}
+
+FailureOr<Configuration> AtomSlmTransferOp::applyRule(const Configuration& in) {
+  Configuration out = in;
+
+  auto* source = out.lookup(getFrom());
+  if (source == nullptr || source->empty()) {
+    return emitOpError() << "the configuration reaching this operation holds no atom at @" << getFrom();
+  }
+  if (source->size() != 1 || (*source)[0].size() != 1) {
+    return emitOpError() << "@" << getFrom() << " holds " << out.getLoad(getFrom())
+                         << " atoms; a tweezer handoff carries exactly one, use `qcc.atom.aod_move` for a group";
+  }
+
+  const Word atom = (*source)[0];
+  source->clear();
+
+  const auto load = out.getLoad(getTo()) + 1;
+  if (const auto capacity = getSubstrateOf(*this).lookupSite(getTo()).getCapacity(); load > capacity) {
+    return emitOpError() << "would place " << load << " atoms at @" << getTo() << ", exceeding its capacity of "
+                         << capacity;
+  }
+
+  out.lookupOrAdd(getTo()).push_back(atom);
+
+  return out;
+}
+
+//===----------------------------------------------------------------------===//
+// LinkGenerateOp
+//===----------------------------------------------------------------------===//
+
+HyperedgeAttr LinkGenerateOp::getEdge() { return getSubstrateOf(*this).lookupEdge(EdgeKind::Link, getVia()); }
+
+LogicalResult LinkGenerateOp::verify() {
+  const auto edge = getEdge();
+  if (!edge) {
+    return emitOpError() << "substrate declares no link edge with id '" << getVia() << "'";
+  }
+
+  // A permanent coupler exists unconditionally: there is nothing to herald and
+  // nothing that could later be consumed.
+  if (edge.isPersistent()) {
+    return emitOpError() << "link edge '" << getVia()
+                         << "' is persistent, so it is available without being generated; only a link declared "
+                            "`persistent = false` is a resource to herald";
+  }
+
+  const auto qubits = getQubits();
+  if (qubits.size() != edge.getSites().size()) {
+    return emitOpError() << "link edge '" << getVia() << "' joins " << edge.getSites().size() << " site(s), but "
+                         << qubits.size() << " qubit(s) were given";
+  }
+
+  llvm::DenseSet<int64_t> seen;
+  for (const int64_t qubit : qubits) {
+    if (!seen.insert(qubit).second) {
+      return emitOpError() << "qubit " << qubit << " is named twice as a party to the link";
+    }
+  }
+
+  return success();
+}
+
+FailureOr<Configuration> LinkGenerateOp::applyRule(const Configuration& in) {
+  Configuration out = in;
+  const auto edge = getEdge();
+  const auto qubits = getQubits();
+
+  // Party `i` must occupy site `i` of the edge, since a photon leaves the module
+  // its emitter is in.
+  for (const auto& [site, qubit] : llvm::zip_equal(edge.getSites(), qubits)) {
+    const auto where = out.findQubit(qubit);
+    if (!where) {
+      return emitOpError() << "qubit " << qubit << " is not placed anywhere, so it cannot be a party to a link";
+    }
+    if (*where != site.getValue()) {
+      return emitOpError() << "qubit " << qubit << " sits at @" << *where << ", but link edge '" << getVia()
+                           << "' expects that party at @" << site.getValue();
+    }
+    // One communication qubit holds one link at a time.
+    if (out.isEntangled(qubit)) {
+      return emitOpError() << "qubit " << qubit
+                           << " already holds a live link; spend it with `qcc.link.consume` before heralding another";
+    }
+  }
+
+  // The party order is preserved rather than sorted. Bell and GHZ resources are
+  // largely symmetric, but which party sits at which end of the fibre is a
+  // property of the resource, and a graph state depends on it. Matching a link
+  // for consumption remains order-insensitive; only the record is ordered.
+  out.links.emplace_back(qubits.begin(), qubits.end());
+
+  return out;
+}
+
+double LinkGenerateOp::getLatencyUs() {
+  const auto edge = getEdge();
+  return edge ? edge.getLatencyUs() : 0.0;
+}
+
+//===----------------------------------------------------------------------===//
+// LinkConsumeOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult LinkConsumeOp::verify() {
+  const auto qubits = getQubits();
+  if (qubits.size() < 2) {
+    return emitOpError() << "a link joins at least two qubits, but " << qubits.size() << " were given";
+  }
+
+  llvm::DenseSet<int64_t> seen;
+  for (const int64_t qubit : qubits) {
+    if (!seen.insert(qubit).second) {
+      return emitOpError() << "qubit " << qubit << " is named twice as a party to the link";
+    }
+  }
+
+  return success();
+}
+
+FailureOr<Configuration> LinkConsumeOp::applyRule(const Configuration& in) {
+  Configuration out = in;
+
+  const Word parties(getQubits().begin(), getQubits().end());
+
+  const auto live = out.findLink(parties);
+  if (!live) {
+    std::string wanted;
+    llvm::raw_string_ostream os(wanted);
+    llvm::interleaveComma(parties, os);
+    return emitOpError() << "no live link joins {" << wanted
+                         << "} in the configuration reaching this operation; a link is spent by use, so it has to be "
+                            "heralded again before it can be spent again";
+  }
+  out.links.erase(out.links.begin() + *live);
+
+  return out;
+}
+
+//===----------------------------------------------------------------------===//
+// IonJunctionTurnOp
+//===----------------------------------------------------------------------===//
+
+LogicalResult IonJunctionTurnOp::verify() {
+  if (failed(verifyDeclaredSite(*this, getSiteAttr(), "junction"))) {
+    return failure();
+  }
+
+  const auto substrate = getSubstrateOf(*this);
+  const auto junction = substrate.lookupSite(getSite());
+
+  // A turn joins two segments, both of which must be incident to this junction.
+  for (const auto& [role, id] : {std::pair{"incoming", getFrom()}, std::pair{"outgoing", getTo()}}) {
+    const auto edge = substrate.lookupEdge(EdgeKind::Transport, id);
+    if (!edge) {
+      return emitOpError() << "substrate declares no transport edge with id '" << id << "'";
+    }
+    if (!edge.contains(getSite())) {
+      return emitOpError() << role << " segment '" << id << "' is not incident to @" << getSite();
+    }
+  }
+
+  if (getFrom() == getTo()) {
+    return emitOpError() << "a turn joins two different segments, but both are '" << getFrom()
+                         << "'; a crystal that leaves the way it came needs no rotation";
+  }
+
+  // The turn-restriction table is a property of the junction, in the same way
+  // that a road network attaches it to the node rather than to a ternary edge.
+  if (junction && !junction.permitsTurn(getFrom(), getTo())) {
+    return emitOpError() << "@" << getSite() << " does not permit the turn '" << getFrom() << "' -> '" << getTo()
+                         << "'; its turn table lists the rotations the hardware can actually perform";
+  }
+
+  return success();
+}
+
+FailureOr<Configuration> IonJunctionTurnOp::applyRule(const Configuration& in) {
+  Configuration out = in;
+  // A rotation changes which segment the crystal faces, not where it is or how
+  // its ions are ordered. The configuration records position only; the facing is
+  // implied by the transport the turn has made legal.
+  const auto located = findChain(*this, out, getSite(), getChain());
+  if (failed(located)) {
+    return failure();
+  }
+  return out;
+}
+
+double IonJunctionTurnOp::getLatencyUs() {
+  const auto junction = getSubstrateOf(*this).lookupSite(getSite());
+  return junction ? junction.getTurnLatencyUs() : 0.0;
+}
+
+//===----------------------------------------------------------------------===//
+// Footprints
+//
+// What each rule touches, which determines whether two of them may be
+// reordered. The sites come from the rule's own attributes; the control
+// resources come from the substrate, as the `control` edges covering those
+// sites.
+//===----------------------------------------------------------------------===//
+
+namespace qcc::conn {
+
+namespace {
+
+/// The ids of every control edge incident to any of `sites`, that is, the
+/// control resources a rule acting on those sites contends for.
+llvm::SmallVector<std::string> contendedControls(Operation* op, llvm::ArrayRef<std::string> sites) {
+  llvm::SmallVector<std::string> uses;
+  for (const auto edge : getSubstrateOf(op).getEdgesOfKind(EdgeKind::Control)) {
+    const bool touches = llvm::any_of(sites, [&](const std::string& site) { return edge.contains(site); });
+    if (touches && !edge.getId().empty()) {
+      uses.emplace_back(edge.getId());
+    }
+  }
+  return uses;
+}
+
+Footprint footprintOver(Operation* op, llvm::ArrayRef<llvm::StringRef> sites) {
+  Footprint footprint;
+  for (const auto site : sites) {
+    if (!site.empty()) {
+      footprint.sites.emplace_back(site);
+    }
+  }
+  footprint.uses = contendedControls(op, footprint.sites);
+  return footprint;
+}
+
+} // namespace
+
+} // namespace qcc::conn
+
+Footprint IonSplitOp::getFootprint() { return footprintOver(*this, {getSite()}); }
+
+Footprint IonMergeOp::getFootprint() { return footprintOver(*this, {getSite()}); }
+
+Footprint IonReorderOp::getFootprint() { return footprintOver(*this, {getSite()}); }
+
+Footprint IonJunctionTurnOp::getFootprint() { return footprintOver(*this, {getSite()}); }
+
+// Transport touches both endpoints, since the chain leaves one site and arrives
+// at the other, so a rule acting on either is not independent of it.
+Footprint IonTransportOp::getFootprint() { return footprintOver(*this, {getFrom(), getDestination()}); }
+
+Footprint AtomAodMoveOp::getFootprint() {
+  llvm::SmallVector<llvm::StringRef> sites;
+  if (const auto edge = getEdge()) {
+    for (const auto member : edge.getSites()) {
+      sites.push_back(member.getValue());
+    }
+  }
+  for (const auto destination : getTo()) {
+    sites.push_back(llvm::cast<FlatSymbolRefAttr>(destination).getValue());
+  }
+  return footprintOver(*this, sites);
+}
+
+Footprint AtomSlmTransferOp::getFootprint() { return footprintOver(*this, {getFrom(), getTo()}); }
+
+Footprint LinkGenerateOp::getFootprint() {
+  llvm::SmallVector<llvm::StringRef> sites;
+  if (const auto edge = getEdge()) {
+    for (const auto member : edge.getSites()) {
+      sites.push_back(member.getValue());
+    }
+  }
+  return footprintOver(*this, sites);
+}
+
+Footprint LinkConsumeOp::getFootprint() {
+  // Consuming a link touches wherever its parties are, which the operation does
+  // not name. Reporting the sites of every non-persistent link edge is
+  // conservative: it can only cause the scheduler to serialise more.
+  llvm::SmallVector<llvm::StringRef> sites;
+  for (const auto edge : getSubstrateOf(*this).getEdgesOfKind(EdgeKind::Link)) {
+    if (edge.isPersistent()) {
+      continue;
+    }
+    for (const auto member : edge.getSites()) {
+      sites.push_back(member.getValue());
+    }
+  }
+  return footprintOver(*this, sites);
+}

--- a/mlir/lib/Dialect/QCC/Transforms/AttachDevice.cpp
+++ b/mlir/lib/Dialect/QCC/Transforms/AttachDevice.cpp
@@ -1,0 +1,79 @@
+// ===----------------------------------------------------------------------===//
+//
+// Part of the FullStaQD Project, under the Apache License v2.0 with LLVM
+// Exceptions.
+// See <repo-root>/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// ===----------------------------------------------------------------------===//
+
+#include "qcc/Dialect/QCC/Devices/DeviceLibrary.h"
+#include "qcc/Dialect/QCC/IR/QCC.h"
+#include "qcc/Dialect/QCC/Transforms/Passes.h" // IWYU pragma: keep
+
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Support/LLVM.h"
+
+#include <llvm/ADT/STLExtras.h>
+#include <llvm/Support/raw_ostream.h>
+#include <string>
+
+namespace qcc {
+
+#define GEN_PASS_DEF_ATTACHDEVICE
+#include "qcc/Dialect/QCC/Transforms/Passes.h.inc"
+
+using namespace mlir;
+using namespace qcc::conn;
+
+namespace {
+
+/// The machines this build knows, for a diagnostic the user can act on.
+std::string knownDevices() {
+  std::string names;
+  llvm::raw_string_ostream os(names);
+  llvm::interleaveComma(getDevices(), os, [&](const DeviceEntry& entry) { os << entry.name; });
+  return names;
+}
+
+struct AttachDevice final : public impl::AttachDeviceBase<AttachDevice> {
+  using AttachDeviceBase<AttachDevice>::AttachDeviceBase;
+
+protected:
+  void runOnOperation() override {
+    ModuleOp moduleOp = getOperation();
+
+    if (device.empty()) {
+      moduleOp.emitError() << "no machine named: pass `device=<name>` to say which one to compile for";
+      return signalPassFailure();
+    }
+
+    const auto* entry = lookupDevice(device);
+    if (entry == nullptr) {
+      moduleOp.emitError() << "unknown machine '" << device << "'; this build knows " << knownDevices();
+      return signalPassFailure();
+    }
+
+    const auto attribute = entry->build(&getContext());
+    if (!attribute) {
+      moduleOp.emitError() << "machine '" << device << "' failed to build; this is a bug in its description";
+      return signalPassFailure();
+    }
+
+    // An existing attribute is the user's. Overwriting it would silently
+    // recompile for a machine they did not ask for.
+    if (const auto existing = moduleOp->getAttrOfType<DeviceAttr>(kDeviceAttrName)) {
+      if (existing != attribute) {
+        moduleOp.emitError() << "module is already attached to a different machine; remove the `" << kDeviceAttrName
+                             << "` attribute to retarget it";
+        return signalPassFailure();
+      }
+      return;
+    }
+
+    moduleOp->setAttr(kDeviceAttrName, attribute);
+  }
+};
+
+} // namespace
+} // namespace qcc

--- a/mlir/lib/Dialect/QCC/Transforms/CMakeLists.txt
+++ b/mlir/lib/Dialect/QCC/Transforms/CMakeLists.txt
@@ -1,0 +1,22 @@
+add_mlir_dialect_library(
+  QCCQCCTransforms
+  AttachDevice.cpp
+  OptimizeShuttling.cpp
+  PlaceQubits.cpp
+  Route.cpp
+  ScheduleConcurrency.cpp
+  VerifyConnectivity.cpp
+  DEPENDS
+  QCCQCCTransformsIncGen
+  LINK_LIBS
+  PUBLIC
+  QCCQCCDialect
+  QCCQCCAnalysis
+  QCCQCCDevices
+  MLIRIR
+  MLIRPass
+  MLIRSupport
+  MLIRFuncDialect
+  MLIRQCDialect)
+
+mqt_mlir_target_use_project_options(QCCQCCTransforms)

--- a/mlir/lib/Dialect/QCC/Transforms/OptimizeShuttling.cpp
+++ b/mlir/lib/Dialect/QCC/Transforms/OptimizeShuttling.cpp
@@ -1,0 +1,116 @@
+// ===----------------------------------------------------------------------===//
+//
+// Part of the FullStaQD Project, under the Apache License v2.0 with LLVM
+// Exceptions.
+// See <repo-root>/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// ===----------------------------------------------------------------------===//
+
+#include "qcc/Dialect/QCC/IR/QCC.h"
+#include "qcc/Dialect/QCC/Transforms/Passes.h" // IWYU pragma: keep
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/QC/IR/QCInterfaces.h"
+#include "mlir/Dialect/QC/IR/QCOps.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/Support/LLVM.h"
+
+#include <llvm/ADT/STLExtras.h>
+#include <llvm/ADT/SmallVector.h>
+#include <llvm/Support/Casting.h>
+
+namespace qcc {
+
+#define GEN_PASS_DEF_OPTIMIZESHUTTLING
+#include "qcc/Dialect/QCC/Transforms/Passes.h.inc"
+
+using namespace mlir;
+using namespace qcc::conn;
+
+namespace {
+
+/// Whether `op` observes the configuration.
+///
+/// Gates are checked against the configuration in force. Measurement and reset
+/// observe it too, since a qubit must be somewhere its readout can reach.
+bool observesConfiguration(Operation* op) { return llvm::isa<qc::UnitaryOpInterface, qc::MeasureOp, qc::ResetOp>(op); }
+
+/// The last operation in `block` that observes the configuration, or nullptr.
+Operation* lastObserver(Block& block) {
+  Operation* last = nullptr;
+  for (Operation& op : block) {
+    if (observesConfiguration(&op)) {
+      last = &op;
+    }
+  }
+  return last;
+}
+
+struct OptimizeShuttling final : public impl::OptimizeShuttlingBase<OptimizeShuttling> {
+  using OptimizeShuttlingBase<OptimizeShuttling>::OptimizeShuttlingBase;
+
+protected:
+  void runOnOperation() override {
+    func::FuncOp function = getOperation();
+    if (function.isExternal()) {
+      return;
+    }
+
+    unsigned removed = 0;
+    double saved = 0.0;
+    for (Block& block : function.getBody()) {
+      for (Operation* op : findUnobservedTail(block, saved)) {
+        op->erase();
+        ++removed;
+      }
+    }
+
+    if (removed > 0) {
+      function.emitRemark() << "dropped " << removed << " unobserved rewrite(s), saving " << saved
+                            << " us of machine time";
+    }
+  }
+
+private:
+  /// The maximal suffix of rewrites that no observer reads, latest first.
+  ///
+  /// A schedule routinely ends by returning ions to where they started; when
+  /// nothing is executed afterwards, that motion costs machine time for no
+  /// observable effect. Only removal is attempted: two shuttles commute when
+  /// their footprints are disjoint, but acting on that needs the concurrency
+  /// analysis, so reordering is left to `--qcc-schedule-concurrency`.
+  llvm::SmallVector<Operation*> findUnobservedTail(Block& block, double& saved) {
+    Operation* observer = lastObserver(block);
+    llvm::SmallVector<Operation*> doomed;
+
+    for (Operation& op : llvm::reverse(block)) {
+      if (observer != nullptr && op.isBeforeInBlock(observer)) {
+        break;
+      }
+
+      auto rule = llvm::dyn_cast<TopologyRewriteOpInterface>(&op);
+      if (!rule) {
+        // A terminator or unrelated operation can be scanned past, but anything
+        // consuming a configuration ends the safe suffix.
+        if (llvm::any_of(op.getOperands(), [](Value v) { return llvm::isa<ConfigType>(v.getType()); })) {
+          break;
+        }
+        continue;
+      }
+
+      const bool observed = llvm::any_of(rule.getOutputConfig().getUsers(),
+                                         [&](Operation* user) { return !llvm::is_contained(doomed, user); });
+      if (observed) {
+        break;
+      }
+
+      doomed.push_back(&op);
+      saved += rule.getLatencyUs();
+    }
+    return doomed;
+  }
+};
+
+} // namespace
+} // namespace qcc

--- a/mlir/lib/Dialect/QCC/Transforms/PlaceQubits.cpp
+++ b/mlir/lib/Dialect/QCC/Transforms/PlaceQubits.cpp
@@ -1,0 +1,129 @@
+// ===----------------------------------------------------------------------===//
+//
+// Part of the FullStaQD Project, under the Apache License v2.0 with LLVM
+// Exceptions.
+// See <repo-root>/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// ===----------------------------------------------------------------------===//
+
+#include "qcc/Dialect/QCC/Devices/DeviceLibrary.h"
+#include "qcc/Dialect/QCC/IR/QCC.h"
+#include "qcc/Dialect/QCC/Transforms/Passes.h" // IWYU pragma: keep
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/QC/IR/QCOps.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/IR/BuiltinOps.h"
+#include "mlir/Support/LLVM.h"
+
+#include <cstdint>
+#include <iterator>
+#include <llvm/ADT/STLExtras.h>
+#include <llvm/ADT/SetVector.h>
+#include <llvm/Support/Casting.h>
+
+namespace qcc {
+
+#define GEN_PASS_DEF_PLACEQUBITS
+#include "qcc/Dialect/QCC/Transforms/Passes.h.inc"
+
+using namespace mlir;
+using namespace qcc::conn;
+
+namespace {
+
+/// Whether `function` already establishes a configuration of its own.
+bool isHardwareAware(func::FuncOp function) {
+  bool found = false;
+  function.walk([&](Operation* op) {
+    found |= llvm::any_of(op->getResults(), [](Value result) { return llvm::isa<ConfigType>(result.getType()); });
+  });
+  return found;
+}
+
+/// Every hardware qubit the function names, in first-mention order.
+llvm::SetVector<int64_t> collectQubits(func::FuncOp function) {
+  llvm::SetVector<int64_t> qubits;
+  function.walk([&](qc::StaticOp op) { qubits.insert(static_cast<int64_t>(op.getIndex())); });
+  return qubits;
+}
+
+struct PlaceQubits final : public impl::PlaceQubitsBase<PlaceQubits> {
+  using PlaceQubitsBase<PlaceQubits>::PlaceQubitsBase;
+
+protected:
+  void runOnOperation() override {
+    func::FuncOp function = getOperation();
+    if (function.isExternal()) {
+      return;
+    }
+
+    auto moduleOp = function->getParentOfType<ModuleOp>();
+    const auto device = moduleOp ? moduleOp->getAttrOfType<DeviceAttr>(kDeviceAttrName) : DeviceAttr{};
+    // With no machine attached there is nothing to place against, and the pass
+    // has to be harmless in a pipeline compiling programs with none.
+    if (!device) {
+      return;
+    }
+
+    // A function establishing its own configuration is hardware-aware already,
+    // and its author's placement is not this pass's to replace.
+    if (isHardwareAware(function)) {
+      return;
+    }
+
+    const auto qubits = collectQubits(function);
+    if (qubits.empty()) {
+      return;
+    }
+
+    const auto config = layOut(device, qubits);
+    if (failed(config)) {
+      return signalPassFailure();
+    }
+
+    Block& entry = function.getBody().front();
+    OpBuilder builder(&entry, entry.begin());
+    ConfigInitOp::create(builder, function.getLoc(), ConfigType::get(&getContext(), device),
+                         PlacementAttr::get(&getContext(), *config));
+  }
+
+private:
+  /// Assigns qubits to sites in declaration order, filling each to capacity.
+  ///
+  /// On a machine of capacity-1 sites this is the identity mapping. It respects
+  /// capacity and never places a qubit twice, so what it produces verifies, but
+  /// it does not read the gate graph and so hands the router more work than a
+  /// placement heuristic would. Replacing this function is the intended way to
+  /// supply one: everything downstream consumes the `qcc.config.init`.
+  FailureOr<Configuration> layOut(DeviceAttr device, const llvm::SetVector<int64_t>& qubits) {
+    Configuration config;
+    auto next = qubits.begin();
+
+    for (const auto site : device.getSubstrate().getSites()) {
+      Word occupants;
+      for (uint64_t taken = 0; taken < site.getCapacity() && next != qubits.end(); ++taken, ++next) {
+        occupants.push_back(*next);
+      }
+      // Empty sites are listed too, so the initial configuration describes the
+      // whole machine rather than only its occupied part.
+      SiteContents groups;
+      if (!occupants.empty()) {
+        groups.push_back(std::move(occupants));
+      }
+      config.sites.push_back({site.getSymName().str(), std::move(groups)});
+    }
+
+    if (next != qubits.end()) {
+      const auto placed = static_cast<size_t>(std::distance(qubits.begin(), next));
+      getOperation().emitError() << "machine has room for " << placed << " of the " << qubits.size()
+                                 << " qubit(s) this function uses";
+      return failure();
+    }
+    return config;
+  }
+};
+
+} // namespace
+} // namespace qcc

--- a/mlir/lib/Dialect/QCC/Transforms/QCCGateWalker.h
+++ b/mlir/lib/Dialect/QCC/Transforms/QCCGateWalker.h
@@ -1,0 +1,56 @@
+// ===----------------------------------------------------------------------===//
+//
+// Part of the FullStaQD Project, under the Apache License v2.0 with LLVM
+// Exceptions.
+// See <repo-root>/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// ===----------------------------------------------------------------------===//
+//
+// Helpers shared by the passes that check `qc` gates against a configuration.
+//
+// ===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "qcc/Dialect/QCC/Analysis/ConnectivityAnalysis.h"
+
+#include "mlir/Dialect/QC/IR/QCInterfaces.h"
+#include "mlir/Dialect/QC/IR/QCOps.h"
+#include "mlir/IR/Operation.h"
+
+#include <cstdint>
+#include <llvm/ADT/SmallVector.h>
+#include <llvm/Support/Casting.h>
+#include <optional>
+
+namespace qcc::conn {
+
+/// Whether connectivity constrains `op`.
+///
+/// A barrier is a scheduling fence rather than an interaction. A modifier
+/// (`qc.ctrl`, `qc.inv`, `qc.pow`) reports the composite qubit set of its whole
+/// body, and its body addresses qubits through aliased block arguments carrying
+/// no index, so the modifier is both the complete check and the only one
+/// possible.
+inline bool isConstrainedByConnectivity(mlir::Operation* op) {
+  return !llvm::isa<mlir::qc::BarrierOp>(op) && !llvm::isa_and_present<mlir::qc::UnitaryOpInterface>(op->getParentOp());
+}
+
+/// The qubits `gate` acts on, or nullopt if any carries no program index.
+///
+/// Controls are included: a controlled gate is an interaction between every
+/// qubit it names, whatever the roles are in the unitary.
+inline std::optional<llvm::SmallVector<int64_t>> collectQubits(mlir::qc::UnitaryOpInterface gate) {
+  llvm::SmallVector<int64_t> qubits;
+  for (size_t i = 0; i < gate.getNumQubits(); ++i) {
+    const auto index = getQubitIndex(gate.getQubit(i));
+    if (!index) {
+      return std::nullopt;
+    }
+    qubits.push_back(*index);
+  }
+  return qubits;
+}
+
+} // namespace qcc::conn

--- a/mlir/lib/Dialect/QCC/Transforms/Route.cpp
+++ b/mlir/lib/Dialect/QCC/Transforms/Route.cpp
@@ -1,0 +1,137 @@
+// ===----------------------------------------------------------------------===//
+//
+// Part of the FullStaQD Project, under the Apache License v2.0 with LLVM
+// Exceptions.
+// See <repo-root>/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// ===----------------------------------------------------------------------===//
+
+#include "qcc/Dialect/QCC/Analysis/ConnectivityAnalysis.h"
+#include "qcc/Dialect/QCC/IR/QCC.h"
+#include "qcc/Dialect/QCC/Transforms/Passes.h" // IWYU pragma: keep
+
+#include "QCCGateWalker.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/QC/IR/QCInterfaces.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/Support/LLVM.h"
+#include "mlir/Support/WalkResult.h"
+
+#include <cstdint>
+#include <llvm/ADT/DenseMap.h>
+#include <llvm/ADT/STLExtras.h>
+#include <llvm/Support/Casting.h>
+#include <llvm/Support/raw_ostream.h>
+#include <string>
+
+namespace qcc {
+
+#define GEN_PASS_DEF_ROUTE
+#include "qcc/Dialect/QCC/Transforms/Passes.h.inc"
+
+using namespace mlir;
+using namespace qcc::conn;
+
+namespace {
+
+/// Where each of `qubits` currently sits, for a reader who has to move them.
+std::string describePlacement(const Configuration& config, llvm::ArrayRef<int64_t> qubits) {
+  std::string text;
+  llvm::raw_string_ostream os(text);
+  llvm::interleaveComma(qubits, os, [&](const int64_t qubit) {
+    os << qubit << " at ";
+    if (const auto site = config.findQubit(qubit)) {
+      os << "@" << *site;
+    } else {
+      os << "no site";
+    }
+  });
+  return text;
+}
+
+struct Route final : public impl::RouteBase<Route> {
+  using RouteBase<Route>::RouteBase;
+
+protected:
+  void runOnOperation() override {
+    func::FuncOp function = getOperation();
+
+    auto& configs = getAnalysis<DominatingConfigMap>();
+    if (configs.empty()) {
+      return markAllAnalysesPreserved();
+    }
+
+    ConfigurationAnalysis analysis(function);
+    llvm::DenseMap<Value, InteractionComplex> complexes;
+    unsigned unroutable = 0;
+
+    const auto result = function.walk(
+        [&](qc::UnitaryOpInterface gate) { return checkGate(gate, configs, analysis, complexes, unroutable); });
+
+    if (result.wasInterrupted() || (unroutable > 0 && !emitRemarks)) {
+      signalPassFailure();
+    }
+
+    markAllAnalysesPreserved();
+  }
+
+private:
+  /// Reports `gate` when the configuration in force cannot execute it. Gates
+  /// this pass cannot evaluate are skipped rather than reported, since
+  /// `--qcc-verify-connectivity` is the pass that judges them.
+  WalkResult checkGate(qc::UnitaryOpInterface gate, DominatingConfigMap& configs, ConfigurationAnalysis& analysis,
+                       llvm::DenseMap<Value, InteractionComplex>& complexes, unsigned& unroutable) {
+    Operation* op = gate.getOperation();
+    if (!isConstrainedByConnectivity(op) || gate.getNumQubits() < 2) {
+      return WalkResult::advance();
+    }
+
+    const auto lookup = configs.at(op);
+    if (!lookup.config || lookup.ambiguous) {
+      return WalkResult::advance();
+    }
+
+    const auto qubits = collectQubits(gate);
+    if (!qubits) {
+      return WalkResult::advance();
+    }
+
+    const auto reaching = analysis.get(lookup.config);
+    if (failed(reaching) || !reaching->isKnown()) {
+      return WalkResult::advance();
+    }
+
+    const auto device = llvm::cast<ConfigType>(lookup.config.getType()).getDevice();
+    const Configuration& config = *reaching->config;
+    const auto& complex = complexes.try_emplace(lookup.config, device, config).first->second;
+    if (complex.isExecutable(*qubits)) {
+      return WalkResult::advance();
+    }
+
+    ++unroutable;
+    report(op, device, config, *qubits);
+    return emitRemarks ? WalkResult::advance() : WalkResult::interrupt();
+  }
+
+  /// States which set is unreachable and where its members are, which is what a
+  /// router consumes. Finding the sequence that brings them together is pebble
+  /// motion with capacities and chain order, and is not attempted here.
+  void report(Operation* op, DeviceAttr device, const Configuration& config, llvm::ArrayRef<int64_t> qubits) {
+    std::string operands;
+    llvm::raw_string_ostream os(operands);
+    llvm::interleaveComma(qubits, os);
+
+    auto diagnostic = emitRemarks ? op->emitRemark() : op->emitOpError();
+    diagnostic << "needs routing: {" << operands << "} is not executable here";
+    diagnostic.attachNote(op->getLoc()) << "currently " << describePlacement(config, qubits);
+    if (device.isStatic()) {
+      diagnostic.attachNote() << "this machine has no rewrite rules, so no shuttle can fix it; the router has to "
+                                 "insert SWAP gates into the program instead";
+    }
+  }
+};
+
+} // namespace
+} // namespace qcc

--- a/mlir/lib/Dialect/QCC/Transforms/ScheduleConcurrency.cpp
+++ b/mlir/lib/Dialect/QCC/Transforms/ScheduleConcurrency.cpp
@@ -1,0 +1,118 @@
+// ===----------------------------------------------------------------------===//
+//
+// Part of the FullStaQD Project, under the Apache License v2.0 with LLVM
+// Exceptions.
+// See <repo-root>/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// ===----------------------------------------------------------------------===//
+
+#include "qcc/Dialect/QCC/IR/QCC.h"
+#include "qcc/Dialect/QCC/Transforms/Passes.h" // IWYU pragma: keep
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/IR/Builders.h"
+#include "mlir/Support/LLVM.h"
+
+#include <algorithm>
+#include <cstdint>
+#include <llvm/ADT/STLExtras.h>
+#include <llvm/ADT/SmallVector.h>
+
+namespace qcc {
+
+#define GEN_PASS_DEF_SCHEDULECONCURRENCY
+#include "qcc/Dialect/QCC/Transforms/Passes.h.inc"
+
+using namespace mlir;
+using namespace qcc::conn;
+
+namespace {
+
+/// One rewrite and its placement in the schedule.
+struct Slot {
+  TopologyRewriteOpInterface rule;
+  Footprint footprint;
+  double latency;
+  unsigned step;
+};
+
+/// What the schedule costs and why.
+struct Schedule {
+  unsigned depth = 0;
+  double criticalPath = 0.0;
+  /// Pairs held apart by a shared control resource alone.
+  unsigned controlBound = 0;
+};
+
+struct ScheduleConcurrency final : public impl::ScheduleConcurrencyBase<ScheduleConcurrency> {
+  using ScheduleConcurrencyBase<ScheduleConcurrency>::ScheduleConcurrencyBase;
+
+protected:
+  void runOnOperation() override {
+    func::FuncOp function = getOperation();
+
+    llvm::SmallVector<Slot> slots;
+    function.walk(
+        [&](TopologyRewriteOpInterface rule) { slots.push_back({rule, rule.getFootprint(), rule.getLatencyUs(), 0}); });
+    if (slots.empty()) {
+      return markAllAnalysesPreserved();
+    }
+
+    const Schedule schedule = assignSteps(slots);
+
+    if (annotate) {
+      OpBuilder builder(&getContext());
+      for (const auto& slot : slots) {
+        slot.rule->setAttr("qcc.step", builder.getI64IntegerAttr(slot.step));
+      }
+    }
+
+    auto report = function.emitRemark() << "scheduled " << slots.size() << " rewrite(s) into " << schedule.depth
+                                        << " step(s); critical path " << schedule.criticalPath << " us";
+    if (schedule.controlBound > 0) {
+      report.attachNote() << schedule.controlBound
+                          << " pair(s) were serialised only by a shared control resource, not by the "
+                             "configuration; they would run together on a machine with one more";
+    }
+  }
+
+private:
+  /// Greedy list scheduling: a rule goes one step after the latest earlier rule
+  /// it cannot share a step with, and in step 0 if it can share with all of
+  /// them. This is the concurrency question, not the reordering one: rules held
+  /// apart only by a control resource still commute.
+  ///
+  /// The SSA chain is not consulted. Threading one configuration value through
+  /// every rule totally orders them in the IR, which is a property of the
+  /// representation rather than of the machine; the footprints are what bind.
+  static Schedule assignSteps(llvm::SmallVectorImpl<Slot>& slots) {
+    Schedule schedule;
+
+    for (const auto& [index, slot] : llvm::enumerate(slots)) {
+      for (size_t earlier = 0; earlier < index; ++earlier) {
+        if (slots[earlier].footprint.concurrentWith(slot.footprint)) {
+          continue;
+        }
+        slots[index].step = std::max(slots[index].step, slots[earlier].step + 1);
+        if (slots[earlier].footprint.serialisedOnlyByControl(slot.footprint)) {
+          ++schedule.controlBound;
+        }
+      }
+      schedule.depth = std::max(schedule.depth, slots[index].step + 1);
+    }
+
+    // The critical path is the sum over steps of the slowest rule in each.
+    llvm::SmallVector<double> stepCost(schedule.depth, 0.0);
+    for (const auto& slot : slots) {
+      stepCost[slot.step] = std::max(stepCost[slot.step], slot.latency);
+    }
+    for (const double cost : stepCost) {
+      schedule.criticalPath += cost;
+    }
+    return schedule;
+  }
+};
+
+} // namespace
+} // namespace qcc

--- a/mlir/lib/Dialect/QCC/Transforms/VerifyConnectivity.cpp
+++ b/mlir/lib/Dialect/QCC/Transforms/VerifyConnectivity.cpp
@@ -1,0 +1,161 @@
+// ===----------------------------------------------------------------------===//
+//
+// Part of the FullStaQD Project, under the Apache License v2.0 with LLVM
+// Exceptions.
+// See <repo-root>/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// ===----------------------------------------------------------------------===//
+
+#include "qcc/Dialect/QCC/Analysis/ConnectivityAnalysis.h"
+#include "qcc/Dialect/QCC/IR/QCC.h"
+#include "qcc/Dialect/QCC/Transforms/Passes.h" // IWYU pragma: keep
+
+#include "QCCGateWalker.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/QC/IR/QCInterfaces.h"
+#include "mlir/IR/Operation.h"
+#include "mlir/Support/LLVM.h"
+#include "mlir/Support/WalkResult.h"
+
+#include <cstdint>
+#include <llvm/ADT/DenseMap.h>
+#include <llvm/ADT/STLExtras.h>
+#include <llvm/Support/Casting.h>
+#include <llvm/Support/raw_ostream.h>
+#include <string>
+
+namespace qcc {
+
+#define GEN_PASS_DEF_VERIFYCONNECTIVITY
+#include "qcc/Dialect/QCC/Transforms/Passes.h.inc"
+
+using namespace mlir;
+using namespace qcc::conn;
+
+namespace {
+
+/// Renders a qubit set as `{a, b, c}`.
+std::string formatSet(llvm::ArrayRef<int64_t> qubits) {
+  std::string text;
+  llvm::raw_string_ostream os(text);
+  os << "{";
+  llvm::interleaveComma(qubits, os);
+  os << "}";
+  return text;
+}
+
+struct VerifyConnectivity final : public impl::VerifyConnectivityBase<VerifyConnectivity> {
+  using VerifyConnectivityBase<VerifyConnectivity>::VerifyConnectivityBase;
+
+protected:
+  void runOnOperation() override {
+    func::FuncOp function = getOperation();
+
+    auto& configs = getAnalysis<DominatingConfigMap>();
+    // A function mentioning no configuration has not opted in, so the pass can
+    // sit in a pipeline that also compiles programs with no device attached.
+    if (configs.empty()) {
+      return markAllAnalysesPreserved();
+    }
+
+    ConfigurationAnalysis analysis(function);
+    llvm::DenseMap<Value, InteractionComplex> complexes;
+
+    const auto result =
+        function.walk([&](qc::UnitaryOpInterface gate) { return checkGate(gate, configs, analysis, complexes); });
+    if (result.wasInterrupted()) {
+      signalPassFailure();
+    }
+
+    markAllAnalysesPreserved();
+  }
+
+private:
+  /// Checks one gate against the configuration in force where it stands.
+  WalkResult checkGate(qc::UnitaryOpInterface gate, DominatingConfigMap& configs, ConfigurationAnalysis& analysis,
+                       llvm::DenseMap<Value, InteractionComplex>& complexes) {
+    Operation* op = gate.getOperation();
+    if (!isConstrainedByConnectivity(op) || gate.getNumQubits() == 0) {
+      return WalkResult::advance();
+    }
+
+    const auto lookup = configs.at(op);
+    if (lookup.ambiguous) {
+      op->emitOpError() << "two configurations reach this operation and neither dominates the other; "
+                           "control flow merged them without an explicit join";
+      return WalkResult::interrupt();
+    }
+    // Nothing establishes a configuration before this point, so no connectivity
+    // is in force to check against.
+    if (!lookup.config) {
+      return WalkResult::advance();
+    }
+
+    const auto qubits = collectQubits(gate);
+    if (!qubits) {
+      if (!requireResolvableQubits) {
+        return WalkResult::advance();
+      }
+      op->emitOpError() << "cannot be checked against connectivity: at least one of its qubits carries no "
+                           "program index; connectivity is stated over hardware qubits, so the operands "
+                           "have to reach a `qc.static`";
+      return WalkResult::interrupt();
+    }
+
+    const auto reaching = analysis.get(lookup.config);
+    // An ill-formed chain has already reported why.
+    if (failed(reaching)) {
+      return WalkResult::interrupt();
+    }
+    if (!reaching->isKnown()) {
+      return reportDynamic(op, *reaching);
+    }
+
+    const Configuration& config = *reaching->config;
+    // Reported before membership, since "qubit 9 is not placed" is a clearer
+    // diagnostic than "no facet contains it".
+    for (const int64_t qubit : *qubits) {
+      if (!config.findQubit(qubit)) {
+        op->emitOpError() << "acts on qubit " << qubit << ", which the configuration reaching it does not place";
+        return WalkResult::interrupt();
+      }
+    }
+
+    // A single-qubit gate is a local rotation. It needs the qubit placed and
+    // nothing more, and on a device that is not downward closed a membership
+    // test would spuriously reject it.
+    if (qubits->size() < 2) {
+      return WalkResult::advance();
+    }
+
+    const auto device = llvm::cast<ConfigType>(lookup.config.getType()).getDevice();
+    const auto& complex = complexes.try_emplace(lookup.config, device, config).first->second;
+    if (complex.isExecutable(*qubits)) {
+      return WalkResult::advance();
+    }
+
+    auto diagnostic =
+        op->emitOpError() << "operand set " << formatSet(*qubits)
+                          << " is not executable in the configuration reaching it: " << complex.explain(*qubits);
+    diagnostic.attachNote(lookup.config.getLoc()) << "connectivity in force here is defined by this value";
+    return WalkResult::interrupt();
+  }
+
+  /// Reports a configuration the analysis could not fold to a constant.
+  WalkResult reportDynamic(Operation* op, const ConfigurationAnalysis::Result& reaching) {
+    auto diagnostic = allowDynamic ? op->emitWarning() : op->emitOpError();
+    diagnostic << "the configuration reaching this operation is not statically known: it is carried by "
+               << (llvm::isa<BlockArgument>(reaching.dynamicOrigin) ? "a loop or region boundary"
+                                                                    : "an operation outside the rule set")
+               << ", so K cannot be computed here";
+    diagnostic.attachNote() << "a configuration crossing a loop boundary is statically known only if the body's "
+                               "net rewrite is the identity; otherwise the choice is a fixpoint over an "
+                               "ordered-partition lattice or a runtime co-location check";
+    return allowDynamic ? WalkResult::advance() : WalkResult::interrupt();
+  }
+};
+
+} // namespace
+} // namespace qcc

--- a/mlir/test/tools/qcc-opt/QCC/qcc-attribute-errors.mlir
+++ b/mlir/test/tools/qcc-opt/QCC/qcc-attribute-errors.mlir
@@ -1,0 +1,160 @@
+// RUN: qcc-opt %s --split-input-file --verify-diagnostics
+
+//===----------------------------------------------------------------------===//
+// Layer 0 well-formedness: checks on the machine description itself, reported at
+// parse time, before any program is written against it.
+//===----------------------------------------------------------------------===//
+
+// Displacement is a binary relation: there is no physical operation moving an
+// ion out of {A, B, C}, and a junction is a site of high degree rather than an
+// edge of high arity.
+#bad_rank = #qcc.substrate<
+  sites = [
+    #qcc.site<name = @a, kind = trap, capacity = 4>,
+    #qcc.site<name = @b, kind = trap, capacity = 4>,
+    #qcc.site<name = @c, kind = trap, capacity = 4>
+  ],
+  // expected-error @+1 {{transport edge must have rank 2, but is incident to 3 sites}}
+  edges = [#qcc.edge<transport, [@a, @b, @c], {id = "seg"}>]>
+
+// -----
+
+// A fixed site holds a single qubit rather than acting as a container, and
+// nothing enters or leaves it. Permitting an incident transport edge would let a
+// superconducting substrate express shuttling.
+// expected-error @+1 {{transport edge 'seg' touches fixed site @q0; a fixed site cannot be entered or left}}
+#shuttling_transmon = #qcc.substrate<
+  sites = [
+    #qcc.site<name = @q0, kind = fixed, capacity = 1>,
+    #qcc.site<name = @t, kind = trap, capacity = 4>
+  ],
+  edges = [#qcc.edge<transport, [@q0, @t], {id = "seg"}>]>
+
+// -----
+
+// `via` addresses a transport edge by name, so an unnamed one is unreachable.
+#no_id = #qcc.substrate<
+  sites = [#qcc.site<name = @a, kind = trap, capacity = 4>, #qcc.site<name = @b, kind = trap, capacity = 4>],
+  // expected-error @+1 {{transport edge must carry a non-empty string `id` property}}
+  edges = [#qcc.edge<transport, [@a, @b], {}>]>
+
+// -----
+
+// expected-error @+1 {{edge refers to undeclared site @nowhere}}
+#dangling = #qcc.substrate<
+  sites = [#qcc.site<name = @a, kind = trap, capacity = 4>],
+  edges = [#qcc.edge<control, [@a, @nowhere], {id = "awg"}>]>
+
+// -----
+
+// `partitioning` asserts that the facets of K partition the qubits, which is
+// what allows the hypergraph to collapse to an ordered partition without loss. A
+// link edge contradicts that by construction: it forms a facet from qubits at
+// several sites, overlapping every group it drew from. Declaring the property
+// regardless would admit a representation that discards the links.
+// expected-error @+1 {{partitioning = true is inconsistent with 1 link edge(s)}}
+#lying_about_partition = #qcc.device<
+  substrate = #qcc.substrate<
+    sites = [#qcc.site<name = @a, kind = trap, capacity = 4>, #qcc.site<name = @b, kind = trap, capacity = 4>],
+    edges = [#qcc.edge<link, [@a, @b], {id = "fibre", persistent = false}>]>,
+  maxFacetRank = 4, downwardClosed = true, partitioning = true, facetOrdering = none>
+
+// -----
+
+// The converse is not an error: a modular ion machine has ordered chains and
+// non-partitioning K simultaneously. Its chains are words a rule can split, and
+// its photonic links lay facets across them. Rejecting this combination would
+// withdraw the whole rule set from any machine with an optical interconnect.
+#chains_plus_links = #qcc.device<
+  substrate = #qcc.substrate<
+    sites = [#qcc.site<name = @a, kind = trap, capacity = 4>, #qcc.site<name = @b, kind = trap, capacity = 4>],
+    edges = [#qcc.edge<link, [@a, @b], {id = "fibre", persistent = false}>]>,
+  maxFacetRank = 4, downwardClosed = true, partitioning = false, facetOrdering = linear>
+
+func.func @split_is_available_on_a_modular_ion_machine() {
+  %c0 = qcc.config.init(#qcc.placement<@a = [[0, 1]], @b = [[2, 3]]>) : !qcc.config<#chains_plus_links>
+  %c1 = qcc.ion.split %c0 {site = @a, chain = 0 : i64,
+                           end = #qcc.chain_end<head>, count = 1 : i64} : !qcc.config<#chains_plus_links>
+  return
+}
+
+// -----
+
+// expected-error @+1 {{fixed site @q0 must have capacity 1, but has 4}}
+#fat_transmon = #qcc.site<name = @q0, kind = fixed, capacity = 4>
+
+// -----
+
+//===----------------------------------------------------------------------===//
+// Layer 1 well-formedness: a placement is a partial injection.
+//===----------------------------------------------------------------------===//
+
+// expected-error @+1 {{qubit 1 is placed more than once}}
+#bilocated = #qcc.placement<@a = [[0, 1]], @b = [[1, 2]]>
+
+// -----
+
+// An empty potential well is not a group.
+// expected-error @+1 {{site @a holds an empty group}}
+#empty_well = #qcc.placement<@a = [[0], []]>
+
+// -----
+
+#ion = #qcc.device<
+  substrate = #qcc.substrate<
+    sites = [#qcc.site<name = @trap_a, kind = trap, capacity = 3>],
+    edges = []>,
+  maxFacetRank = 5, downwardClosed = true, partitioning = true, facetOrdering = linear>
+
+// Capacity is the transient maximum a site can ever hold.
+func.func @over_capacity() {
+  // expected-error @+1 {{places 4 qubits at @trap_a, exceeding its capacity of 3}}
+  %c = qcc.config.init(#qcc.placement<@trap_a = [[0, 1, 2, 3]]>) : !qcc.config<#ion>
+  return
+}
+
+// -----
+
+#ion = #qcc.device<
+  substrate = #qcc.substrate<
+    sites = [#qcc.site<name = @trap_a, kind = trap, capacity = 3>],
+    edges = []>,
+  maxFacetRank = 5, downwardClosed = true, partitioning = true, facetOrdering = linear>
+
+func.func @undeclared_site() {
+  // expected-error @+1 {{places qubits at @trap_z, which the substrate does not declare}}
+  %c = qcc.config.init(#qcc.placement<@trap_z = [[0]]>) : !qcc.config<#ion>
+  return
+}
+
+// -----
+
+#ion = #qcc.device<
+  substrate = #qcc.substrate<
+    sites = [#qcc.site<name = @trap_a, kind = trap, capacity = 6>],
+    edges = []>,
+  maxFacetRank = 5, downwardClosed = true, partitioning = true, facetOrdering = linear>
+
+func.func @not_a_permutation() {
+  %c0 = qcc.config.init(#qcc.placement<@trap_a = [[0, 1, 2]]>) : !qcc.config<#ion>
+  // expected-error @+1 {{permutation names position 1 twice}}
+  %c1 = qcc.ion.reorder %c0 {site = @trap_a, chain = 0 : i64,
+                             permutation = array<i64: 1, 1, 2>} : !qcc.config<#ion>
+  return
+}
+
+// -----
+
+#ion = #qcc.device<
+  substrate = #qcc.substrate<
+    sites = [#qcc.site<name = @trap_a, kind = trap, capacity = 6>],
+    edges = []>,
+  maxFacetRank = 5, downwardClosed = true, partitioning = true, facetOrdering = linear>
+
+func.func @merge_into_itself() {
+  %c0 = qcc.config.init(#qcc.placement<@trap_a = [[0], [1, 2]]>) : !qcc.config<#ion>
+  // expected-error @+1 {{cannot merge chain 0 into itself}}
+  %c1 = qcc.ion.merge %c0 {site = @trap_a, dst = 0 : i64, src = 0 : i64,
+                           at = #qcc.chain_end<head>} : !qcc.config<#ion>
+  return
+}

--- a/mlir/test/tools/qcc-opt/QCC/qcc-dialect-roundtrip.mlir
+++ b/mlir/test/tools/qcc-opt/QCC/qcc-dialect-roundtrip.mlir
@@ -1,0 +1,206 @@
+// RUN: qcc-opt %s | qcc-opt | FileCheck %s
+
+//===----------------------------------------------------------------------===//
+// Layer 0: a QCCD substrate of two traps joined through a junction.
+//
+// `capacity` is the transient maximum rather than the nominal load: during a
+// merge a trap briefly holds every ion it will hold afterwards plus the arriving
+// chain.
+//===----------------------------------------------------------------------===//
+
+#ion_substrate = #qcc.substrate<
+  sites = [
+    #qcc.site<name = @trap_a, kind = trap, capacity = 20>,
+    #qcc.site<name = @trap_b, kind = trap, capacity = 20>,
+    #qcc.site<name = @j0, kind = junction, capacity = 10>
+  ],
+  edges = [
+    // transport: rank 2. Displacement is binary, and the junction here is a site
+    // of degree 2 rather than an edge of arity 2.
+    #qcc.edge<transport, [@trap_a, @j0], {id = "seg_aj", latency_us = 8.000000e+01, bidirectional = true, max_chain_len = 10 : i64}>,
+    #qcc.edge<transport, [@j0, @trap_b], {id = "seg_jb", latency_us = 8.000000e+01, bidirectional = true, max_chain_len = 10 : i64}>,
+    // control: rank 3. One AWG drives every shuttling electrode, so no two
+    // transports may overlap in time even on disjoint segments. Expanding this
+    // into a clique would lose which conflict comes from which resource.
+    #qcc.edge<control, [@trap_a, @j0, @trap_b], {id = "awg_shuttle"}>,
+    // control: rank 2. A single MS laser switched between the two traps.
+    #qcc.edge<control, [@trap_a, @trap_b], {id = "laser_ms"}>
+  ]>
+
+#ion = #qcc.device<substrate = #ion_substrate,
+                   maxFacetRank = 10,
+                   downwardClosed = true,
+                   partitioning = true,
+                   facetOrdering = linear>
+
+// The whole machine description survives the round trip, including hyperedge
+// ranks and properties. It prints through an alias, since a substrate repeated on
+// every value of a configuration chain is unreadable inline.
+// CHECK-DAG: #[[$SUB:.+]] = #qcc.substrate<sites = [#qcc.site<name = @trap_a, kind = trap, capacity = 20>, #qcc.site<name = @trap_b, kind = trap, capacity = 20>, #qcc.site<name = @j0, kind = junction, capacity = 10>]
+// CHECK-DAG: #qcc.edge<transport, [@trap_a, @j0], {bidirectional = true, id = "seg_aj", latency_us = 8.000000e+01 : f64, max_chain_len = 10 : i64}>
+// CHECK-DAG: #qcc.edge<control, [@trap_a, @j0, @trap_b], {id = "awg_shuttle"}>
+// CHECK-DAG: #[[$ION:.+]] = #qcc.device<substrate = #[[$SUB]], maxFacetRank = 10, downwardClosed = true, partitioning = true, facetOrdering = linear>
+// CHECK-DAG: !config = !qcc.config<#[[$ION]]>
+
+// A site with no overrides prints only its required fields.
+// CHECK-DAG: #qcc.site<name = @store, kind = trap, capacity = 8, coords = [0.000000e+00, 0.000000e+00]>
+// Every override survives, in the order the struct declares them.
+// CHECK-DAG: #qcc.site<name = @plane, kind = trap, capacity = 8, maxFacetRank = 4, facetOrdering = planar, coords = [3.000000e+00, 1.000000e+00, 2.000000e+00]>
+// CHECK-DAG: #qcc.site<name = @j, kind = junction, capacity = 2, props = {turn_latency_us = 4.000000e+02 : f64, turns = ["seg_s>seg_p", "seg_p>seg_s"]}>
+
+// CHECK-LABEL: func.func @shuttle
+func.func @shuttle() {
+  // CHECK: %[[C0:.+]] = qcc.config.init(#qcc.placement<@trap_a = {{\[\[}}0, 1, 2, 3, 4]], @trap_b = {{\[\[}}5, 6, 7, 8, 9]], @j0 = []>) : !config
+  %c0 = qcc.config.init(#qcc.placement<
+      @trap_a = [[0, 1, 2, 3, 4]],
+      @trap_b = [[5, 6, 7, 8, 9]],
+      @j0     = []>) : !qcc.config<#ion>
+
+  // Detach ion 0 from the head of trap_a's chain: [0 1 2 3 4] -> [0] [1 2 3 4].
+  // CHECK: %[[C1:.+]] = qcc.ion.split %[[C0]] {chain = 0 : i64, count = 1 : i64, end = #qcc.chain_end<head>, site = @trap_a} : !config
+  %c1 = qcc.ion.split %c0 {site = @trap_a, chain = 0 : i64,
+                           end = #qcc.chain_end<head>, count = 1 : i64}
+      : !qcc.config<#ion>
+
+  // Two hops: a junction is traversed by two binary displacements.
+  // CHECK: %[[C2:.+]] = qcc.ion.transport %[[C1]] {chain = 0 : i64, from = @trap_a, via = "seg_aj"} : !config
+  %c2 = qcc.ion.transport %c1 {from = @trap_a, chain = 0 : i64, via = "seg_aj"}
+      : !qcc.config<#ion>
+  // CHECK: %[[C3:.+]] = qcc.ion.transport %[[C2]] {chain = 0 : i64, from = @j0, via = "seg_jb"} : !config
+  %c3 = qcc.ion.transport %c2 {from = @j0, chain = 0 : i64, via = "seg_jb"}
+      : !qcc.config<#ion>
+
+  // Prepend the arrival onto trap_b's chain: [5 6 7 8 9] [0] -> [0 5 6 7 8 9].
+  // CHECK: %[[C4:.+]] = qcc.ion.merge %[[C3]] {at = #qcc.chain_end<head>, dst = 0 : i64, site = @trap_b, src = 1 : i64} : !config
+  %c4 = qcc.ion.merge %c3 {site = @trap_b, dst = 0 : i64, src = 1 : i64,
+                           at = #qcc.chain_end<head>}
+      : !qcc.config<#ion>
+
+  // CHECK: %[[C5:.+]] = qcc.ion.reorder %[[C4]] {chain = 0 : i64, permutation = array<i64: 1, 0, 2, 3, 4, 5>, site = @trap_b} : !config
+  %c5 = qcc.ion.reorder %c4 {site = @trap_b, chain = 0 : i64,
+                             permutation = array<i64: 1, 0, 2, 3, 4, 5>}
+      : !qcc.config<#ion>
+
+  return
+}
+
+//===----------------------------------------------------------------------===//
+// A superconducting target: the case where the rule set is empty. There are no
+// transport edges, so nothing in the dialect can produce a new configuration.
+// Couplers are rank-2 `link` edges that are never consumed.
+//===----------------------------------------------------------------------===//
+
+#sc = #qcc.device<
+  substrate = #qcc.substrate<
+    sites = [
+      #qcc.site<name = @q0, kind = fixed, capacity = 1>,
+      #qcc.site<name = @q1, kind = fixed, capacity = 1>,
+      #qcc.site<name = @q2, kind = fixed, capacity = 1>
+    ],
+    edges = [
+      #qcc.edge<link, [@q0, @q1], {id = "coupler_01", persistent = true, cz_err = 6.100000e-03}>,
+      #qcc.edge<link, [@q1, @q2], {id = "coupler_12", persistent = true, cz_err = 5.800000e-03}>
+    ]>,
+  maxFacetRank = 2,
+  downwardClosed = true,
+  // couplers overlap: q1 is in both {q0,q1} and {q1,q2}
+  partitioning = false,
+  facetOrdering = none>
+
+// CHECK-LABEL: func.func @static_chip
+func.func @static_chip() {
+  // CHECK: qcc.config.init(#qcc.placement<@q0 = {{\[\[}}0]], @q1 = {{\[\[}}1]], @q2 = {{\[\[}}2]]>)
+  %c = qcc.config.init(#qcc.placement<@q0 = [[0]], @q1 = [[1]], @q2 = [[2]]>)
+      : !qcc.config<#sc>
+  return
+}
+
+// An empty placement is well-formed: nothing is placed yet.
+// CHECK-LABEL: func.func @nothing_placed
+func.func @nothing_placed() {
+  // CHECK: qcc.config.init(#qcc.placement<>) : !config
+  %c = qcc.config.init(#qcc.placement<>) : !qcc.config<#sc>
+  return
+}
+
+//===----------------------------------------------------------------------===//
+// The atom and link rule sets round-trip on the same footing as the ion ones.
+// One dialect covers all three at no cost to the simpler targets: this target
+// declares rigid and link edges, and an ion machine that declares neither never
+// encounters these operations.
+//===----------------------------------------------------------------------===//
+
+#hybrid = #qcc.device<
+  substrate = #qcc.substrate<
+    sites = [
+      #qcc.site<name = @t0, kind = trap, capacity = 2>,
+      #qcc.site<name = @t1, kind = trap, capacity = 2>,
+      #qcc.site<name = @t2, kind = trap, capacity = 2>,
+      #qcc.site<name = @t3, kind = trap, capacity = 2>,
+      #qcc.site<name = @m0, kind = module, capacity = 2>,
+      #qcc.site<name = @m1, kind = module, capacity = 2>
+    ],
+    edges = [
+      #qcc.edge<rigid, [@t0, @t1], {id = "aod_x", axis = "x", latency_us = 5.000000e+02}>,
+      #qcc.edge<rigid, [@t2, @t3], {id = "aod_x2", axis = "x"}>,
+      #qcc.edge<link, [@m0, @m1], {id = "fibre", persistent = false, latency_us = 5.500000e+03}>
+    ]>,
+  maxFacetRank = 2, downwardClosed = true, partitioning = false, facetOrdering = none>
+
+// CHECK-LABEL: func.func @atom_and_link_rules
+func.func @atom_and_link_rules() {
+  // CHECK: %[[C0:.+]] = qcc.config.init
+  %c0 = qcc.config.init(#qcc.placement<
+      @t0 = [[0]], @t1 = [[1]], @m0 = [[2]], @m1 = [[3]]>) : !qcc.config<#hybrid>
+
+  // A whole AOD axis displaced in one step.
+  // CHECK: %[[C1:.+]] = qcc.atom.aod_move %[[C0]] {to = [@t2, @t3], via = "aod_x"}
+  %c1 = qcc.atom.aod_move %c0 {via = "aod_x", to = [@t2, @t3]} : !qcc.config<#hybrid>
+
+  // A single tweezer handoff along an axis that reaches both traps.
+  // CHECK: %[[C2:.+]] = qcc.atom.slm_transfer %[[C1]] {from = @t2, to = @t3}
+  %c2 = qcc.atom.slm_transfer %c1 {from = @t2, to = @t3} : !qcc.config<#hybrid>
+
+  // Herald a link, then consume it. The pair is a facet only in between.
+  // CHECK: %[[C3:.+]] = qcc.link.generate %[[C2]] {qubits = array<i64: 2, 3>, via = "fibre"}
+  %c3 = qcc.link.generate %c2 {via = "fibre", qubits = array<i64: 2, 3>} : !qcc.config<#hybrid>
+  // CHECK: qcc.link.consume %[[C3]] {qubits = array<i64: 2, 3>}
+  %c4 = qcc.link.consume %c3 {qubits = array<i64: 2, 3>} : !qcc.config<#hybrid>
+
+  return
+}
+
+//===----------------------------------------------------------------------===//
+// Per-site overrides, geometry and a junction's turn table all round-trip. Each
+// is optional: a site that declares none inherits the device ordering and rank
+// and permits every turn.
+//===----------------------------------------------------------------------===//
+
+#annotated = #qcc.device<
+  substrate = #qcc.substrate<
+    sites = [
+      #qcc.site<name = @store, kind = trap, capacity = 8, coords = [0.000000e+00, 0.000000e+00]>,
+      #qcc.site<name = @plane, kind = trap, capacity = 8, maxFacetRank = 4, facetOrdering = planar,
+                coords = [3.000000e+00, 1.000000e+00, 2.000000e+00]>,
+      #qcc.site<name = @j, kind = junction, capacity = 2,
+                props = {turn_latency_us = 4.000000e+02, turns = ["seg_s>seg_p", "seg_p>seg_s"]}>
+    ],
+    edges = [
+      #qcc.edge<transport, [@store, @j], {id = "seg_s", bidirectional = true}>,
+      #qcc.edge<transport, [@j, @plane], {id = "seg_p", bidirectional = true}>
+    ]>,
+  maxFacetRank = 8, downwardClosed = true, partitioning = true, facetOrdering = linear>
+
+
+// CHECK-LABEL: func.func @turn_at_a_junction
+func.func @turn_at_a_junction() {
+  // CHECK: %[[C0:.+]] = qcc.config.init
+  %c0 = qcc.config.init(#qcc.placement<@store = [[0, 1]], @j = [], @plane = []>)
+      : !qcc.config<#annotated>
+  // CHECK: %[[C1:.+]] = qcc.ion.transport %[[C0]]
+  %c1 = qcc.ion.transport %c0 {from = @store, chain = 0 : i64, via = "seg_s"} : !qcc.config<#annotated>
+  // CHECK: qcc.ion.junction_turn %[[C1]] {chain = 0 : i64, from = "seg_s", site = @j, to = "seg_p"}
+  %c2 = qcc.ion.junction_turn %c1 {site = @j, chain = 0 : i64, from = "seg_s", to = "seg_p"}
+      : !qcc.config<#annotated>
+  return
+}

--- a/mlir/test/tools/qcc-opt/QCC/qcc-junction-turns.mlir
+++ b/mlir/test/tools/qcc-opt/QCC/qcc-junction-turns.mlir
@@ -1,0 +1,91 @@
+// RUN: qcc-opt %s --split-input-file --verify-diagnostics
+
+//===----------------------------------------------------------------------===//
+// Junction turns.
+//
+// Carrying a crystal straight through a junction and turning it are different
+// physical actions: the turn rotates the crystal, costs substantially more than
+// a hop, and on much hardware is possible only between certain pairs of
+// segments. `qcc.ion.junction_turn` exposes the cost through `getLatencyUs` and
+// the legality through the verifier.
+//
+// The restriction is a `turns` table on the junction, in the same way that a
+// road network attaches turn restrictions to the node rather than to a ternary
+// edge. A junction that declares none permits every turn.
+//===----------------------------------------------------------------------===//
+
+#tee = #qcc.device<
+  substrate = #qcc.substrate<
+    sites = [
+      #qcc.site<name = @north, kind = trap, capacity = 4>,
+      #qcc.site<name = @east, kind = trap, capacity = 4>,
+      #qcc.site<name = @south, kind = trap, capacity = 4>,
+      // North may turn to east and back, but never to south.
+      #qcc.site<name = @j, kind = junction, capacity = 2,
+                props = {turns = ["sn>se", "se>sn"], turn_latency_us = 4.000000e+02}>
+    ],
+    edges = [
+      #qcc.edge<transport, [@north, @j], {id = "sn", latency_us = 1.000000e+02, bidirectional = true}>,
+      #qcc.edge<transport, [@east, @j], {id = "se", latency_us = 1.000000e+02, bidirectional = true}>,
+      #qcc.edge<transport, [@south, @j], {id = "ss", latency_us = 1.000000e+02, bidirectional = true}>
+    ]>,
+  maxFacetRank = 4, downwardClosed = true, partitioning = true, facetOrdering = linear>
+
+func.func @north_to_east_is_permitted() {
+  %c0 = qcc.config.init(#qcc.placement<@north = [[0]], @j = [], @east = []>) : !qcc.config<#tee>
+  %c1 = qcc.ion.transport %c0 {from = @north, chain = 0 : i64, via = "sn"} : !qcc.config<#tee>
+  %c2 = qcc.ion.junction_turn %c1 {site = @j, chain = 0 : i64, from = "sn", to = "se"} : !qcc.config<#tee>
+  %c3 = qcc.ion.transport %c2 {from = @j, chain = 0 : i64, via = "se"} : !qcc.config<#tee>
+  return
+}
+
+func.func @north_to_south_is_not() {
+  %c0 = qcc.config.init(#qcc.placement<@north = [[0]], @j = []>) : !qcc.config<#tee>
+  %c1 = qcc.ion.transport %c0 {from = @north, chain = 0 : i64, via = "sn"} : !qcc.config<#tee>
+  // expected-error @+1 {{@j does not permit the turn 'sn' -> 'ss'; its turn table lists the rotations the hardware can actually perform}}
+  %c2 = qcc.ion.junction_turn %c1 {site = @j, chain = 0 : i64, from = "sn", to = "ss"} : !qcc.config<#tee>
+  return
+}
+
+func.func @a_turn_joins_two_segments() {
+  %c0 = qcc.config.init(#qcc.placement<@north = [[0]], @j = []>) : !qcc.config<#tee>
+  // expected-error @+1 {{a turn joins two different segments, but both are 'sn'; a crystal that leaves the way it came needs no rotation}}
+  %c1 = qcc.ion.junction_turn %c0 {site = @j, chain = 0 : i64, from = "sn", to = "sn"} : !qcc.config<#tee>
+  return
+}
+
+func.func @both_segments_must_reach_the_junction() {
+  %c0 = qcc.config.init(#qcc.placement<@north = [[0]], @j = []>) : !qcc.config<#tee>
+  // expected-error @+1 {{substrate declares no transport edge with id 'nowhere'}}
+  %c1 = qcc.ion.junction_turn %c0 {site = @j, chain = 0 : i64, from = "sn", to = "nowhere"} : !qcc.config<#tee>
+  return
+}
+
+// -----
+
+// A junction that declares no table permits every turn, which is the case where
+// the rotation is unrestricted.
+#unrestricted = #qcc.device<
+  substrate = #qcc.substrate<
+    sites = [#qcc.site<name = @a, kind = trap, capacity = 4>,
+             #qcc.site<name = @b, kind = trap, capacity = 4>,
+             #qcc.site<name = @j, kind = junction, capacity = 2>],
+    edges = [#qcc.edge<transport, [@a, @j], {id = "sa", bidirectional = true}>,
+             #qcc.edge<transport, [@b, @j], {id = "sb", bidirectional = true}>]>,
+  maxFacetRank = 4, downwardClosed = true, partitioning = true, facetOrdering = linear>
+
+func.func @no_table_permits_everything() {
+  %c0 = qcc.config.init(#qcc.placement<@a = [[0]], @j = []>) : !qcc.config<#unrestricted>
+  %c1 = qcc.ion.transport %c0 {from = @a, chain = 0 : i64, via = "sa"} : !qcc.config<#unrestricted>
+  %c2 = qcc.ion.junction_turn %c1 {site = @j, chain = 0 : i64, from = "sa", to = "sb"} : !qcc.config<#unrestricted>
+  return
+}
+
+// -----
+
+// A malformed entry would silently forbid every turn, which is harder to
+// diagnose than a rejected description.
+#bad_table = #qcc.substrate<
+  // expected-error @+1 {{site @j has a malformed `turns` entry; each is "<incoming-id>><outgoing-id>"}}
+  sites = [#qcc.site<name = @j, kind = junction, capacity = 2, props = {turns = ["sn_to_se"]}>],
+  edges = []>

--- a/mlir/test/tools/qcc-opt/QCC/qcc-rewrites-survive-dce.mlir
+++ b/mlir/test/tools/qcc-opt/QCC/qcc-rewrites-survive-dce.mlir
@@ -1,0 +1,72 @@
+// RUN: qcc-opt %s --canonicalize --cse | FileCheck %s
+// RUN: qcc-opt %s --qcc-verify-connectivity=allow-dynamic=true | FileCheck %s --check-prefix=DYNAMIC
+
+#ion = #qcc.device<
+  substrate = #qcc.substrate<
+    sites = [
+      #qcc.site<name = @a, kind = trap, capacity = 6>,
+      #qcc.site<name = @b, kind = trap, capacity = 6>
+    ],
+    edges = [#qcc.edge<transport, [@a, @b], {id = "seg", latency_us = 8.000000e+01}>]>,
+  maxFacetRank = 5, downwardClosed = true, partitioning = true, facetOrdering = linear>
+
+//===----------------------------------------------------------------------===//
+// A rewrite operation describes physical motion, and under the dominating-
+// definition discipline no gate takes its result as an operand. Were these
+// operations `Pure`, an unused configuration chain would be dead code and the
+// shuttle it describes would be eliminated. They write a dedicated side-effect
+// resource instead, which keeps the chain live and ordered.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: func.func @chain_with_no_consumer
+func.func @chain_with_no_consumer() {
+  // CHECK: %[[C0:.+]] = qcc.config.init
+  %c0 = qcc.config.init(#qcc.placement<@a = [[0, 1]], @b = []>) : !qcc.config<#ion>
+  // CHECK: %[[C1:.+]] = qcc.ion.split %[[C0]]
+  %c1 = qcc.ion.split %c0 {site = @a, chain = 0 : i64,
+                           end = #qcc.chain_end<head>, count = 1 : i64} : !qcc.config<#ion>
+  // CHECK: qcc.ion.transport %[[C1]]
+  %c2 = qcc.ion.transport %c1 {from = @a, chain = 0 : i64, via = "seg"} : !qcc.config<#ion>
+  return
+}
+
+//===----------------------------------------------------------------------===//
+// Two syntactically identical transports are two distinct physical moves. CSE
+// must not merge them: the second acts on the configuration the first produced,
+// not on the one the first consumed.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: func.func @identical_moves_are_not_common_subexpressions
+func.func @identical_moves_are_not_common_subexpressions() {
+  %c0 = qcc.config.init(#qcc.placement<@a = [[0], [1]]>) : !qcc.config<#ion>
+  // CHECK-COUNT-2: qcc.ion.transport
+  // CHECK-NOT: qcc.ion.transport
+  %c1 = qcc.ion.transport %c0 {from = @a, chain = 0 : i64, via = "seg"} : !qcc.config<#ion>
+  %c2 = qcc.ion.transport %c1 {from = @a, chain = 0 : i64, via = "seg"} : !qcc.config<#ion>
+  return
+}
+
+//===----------------------------------------------------------------------===//
+// `allow-dynamic` downgrades the loop-carried case from an error to a warning,
+// for pipelines that intend to emit a runtime co-location check rather than
+// prove co-location statically.
+//===----------------------------------------------------------------------===//
+
+// DYNAMIC-LABEL: func.func @loop_carried
+func.func @loop_carried(%theta: f64, %n: index) {
+  %q0 = qc.static 0 : !qc.qubit
+  %q1 = qc.static 1 : !qc.qubit
+  %lb = arith.constant 0 : index
+  %step = arith.constant 1 : index
+  %c0 = qcc.config.init(#qcc.placement<@a = [[0, 1, 2]], @b = []>) : !qcc.config<#ion>
+
+  %cN = scf.for %i = %lb to %n step %step iter_args(%c = %c0) -> (!qcc.config<#ion>) {
+    %ca = qcc.ion.split %c {site = @a, chain = 0 : i64,
+                            end = #qcc.chain_end<head>, count = 1 : i64} : !qcc.config<#ion>
+    // The pass warns rather than failing, and leaves the gate in place.
+    // DYNAMIC: qc.rxx
+    qc.rxx(%theta) %q0, %q1 : !qc.qubit, !qc.qubit
+    scf.yield %ca : !qcc.config<#ion>
+  }
+  return
+}

--- a/mlir/test/tools/qcc-opt/QCC/qcc-schedule-concurrency.mlir
+++ b/mlir/test/tools/qcc-opt/QCC/qcc-schedule-concurrency.mlir
@@ -1,0 +1,75 @@
+// RUN: qcc-opt %s --split-input-file --qcc-schedule-concurrency 2>&1 >/dev/null | FileCheck %s --check-prefix=REPORT
+// RUN: qcc-opt %s --split-input-file --qcc-schedule-concurrency 2>/dev/null | FileCheck %s
+
+//===----------------------------------------------------------------------===//
+// Concurrency from control edges.
+//
+// Two independent constraints decide whether rewrites can share a time step.
+// Their double-pushout footprints must be disjoint, since otherwise applying
+// them in either order gives different configurations; and they must contend for
+// no `control` hyperedge, since otherwise they compete for one waveform
+// generator, which no reasoning about placement can discover.
+//
+// The two modules below differ only in how many waveform generators drive them,
+// and their schedules differ by a factor of two.
+//===----------------------------------------------------------------------===//
+
+#shared_awg = #qcc.device<
+  substrate = #qcc.substrate<
+    sites = [#qcc.site<name = @a0, kind = trap, capacity = 6>, #qcc.site<name = @a1, kind = trap, capacity = 6>,
+             #qcc.site<name = @b0, kind = trap, capacity = 6>, #qcc.site<name = @b1, kind = trap, capacity = 6>],
+    edges = [#qcc.edge<transport, [@a0, @a1], {id = "sa", latency_us = 8.000000e+01, bidirectional = true}>,
+             #qcc.edge<transport, [@b0, @b1], {id = "sb", latency_us = 8.000000e+01, bidirectional = true}>,
+             // ONE generator drives every shuttling electrode on the machine.
+             #qcc.edge<control, [@a0, @a1, @b0, @b1], {id = "awg_all"}>]>,
+  maxFacetRank = 6, downwardClosed = true, partitioning = true, facetOrdering = linear>
+
+func.func @one_generator_for_the_whole_machine() {
+  %c0 = qcc.config.init(#qcc.placement<@a0 = [[0, 1]], @a1 = [], @b0 = [[2, 3]], @b1 = []>)
+      : !qcc.config<#shared_awg>
+  %c1 = qcc.ion.split %c0 {site = @a0, chain = 0 : i64, end = #qcc.chain_end<head>, count = 1 : i64} : !qcc.config<#shared_awg>
+  %c2 = qcc.ion.split %c1 {site = @b0, chain = 0 : i64, end = #qcc.chain_end<head>, count = 1 : i64} : !qcc.config<#shared_awg>
+  %c3 = qcc.ion.transport %c2 {from = @a0, chain = 0 : i64, via = "sa"} : !qcc.config<#shared_awg>
+  %c4 = qcc.ion.transport %c3 {from = @b0, chain = 0 : i64, via = "sb"} : !qcc.config<#shared_awg>
+  return
+}
+
+// Nothing overlaps: four rewrites in four steps.
+// REPORT: scheduled 4 rewrite(s) into 4 step(s); critical path 1.600000e+02 us
+// The count of pairs an additional generator would allow to run concurrently.
+// REPORT: pair(s) were serialised only by a shared control resource
+
+// -----
+
+#own_awg = #qcc.device<
+  substrate = #qcc.substrate<
+    sites = [#qcc.site<name = @a0, kind = trap, capacity = 6>, #qcc.site<name = @a1, kind = trap, capacity = 6>,
+             #qcc.site<name = @b0, kind = trap, capacity = 6>, #qcc.site<name = @b1, kind = trap, capacity = 6>],
+    edges = [#qcc.edge<transport, [@a0, @a1], {id = "sa", latency_us = 8.000000e+01, bidirectional = true}>,
+             #qcc.edge<transport, [@b0, @b1], {id = "sb", latency_us = 8.000000e+01, bidirectional = true}>,
+             // The same machine, with one generator per module.
+             #qcc.edge<control, [@a0, @a1], {id = "awg_a"}>,
+             #qcc.edge<control, [@b0, @b1], {id = "awg_b"}>]>,
+  maxFacetRank = 6, downwardClosed = true, partitioning = true, facetOrdering = linear>
+
+// CHECK-LABEL: func.func @one_generator_per_module
+func.func @one_generator_per_module() {
+  %c0 = qcc.config.init(#qcc.placement<@a0 = [[0, 1]], @a1 = [], @b0 = [[2, 3]], @b1 = []>)
+      : !qcc.config<#own_awg>
+  // The two splits touch different sites and different generators, so they go
+  // in the same step -- even though the SSA chain totally orders them, which is
+  // an artefact of threading one configuration value rather than a fact about
+  // the machine.
+  // CHECK: qcc.ion.split {{.*}}qcc.step = 0
+  %c1 = qcc.ion.split %c0 {site = @a0, chain = 0 : i64, end = #qcc.chain_end<head>, count = 1 : i64} : !qcc.config<#own_awg>
+  // CHECK: qcc.ion.split {{.*}}qcc.step = 0
+  %c2 = qcc.ion.split %c1 {site = @b0, chain = 0 : i64, end = #qcc.chain_end<head>, count = 1 : i64} : !qcc.config<#own_awg>
+  // CHECK: qcc.ion.transport {{.*}}qcc.step = 1
+  %c3 = qcc.ion.transport %c2 {from = @a0, chain = 0 : i64, via = "sa"} : !qcc.config<#own_awg>
+  // CHECK: qcc.ion.transport {{.*}}qcc.step = 1
+  %c4 = qcc.ion.transport %c3 {from = @b0, chain = 0 : i64, via = "sb"} : !qcc.config<#own_awg>
+  return
+}
+
+// The same program over the same segments, in half the steps.
+// REPORT: scheduled 4 rewrite(s) into 2 step(s); critical path 8.000000e+01 us

--- a/mlir/test/tools/qcc-opt/QCC/qcc-site-addressability.mlir
+++ b/mlir/test/tools/qcc-opt/QCC/qcc-site-addressability.mlir
@@ -1,0 +1,173 @@
+// RUN: qcc-opt %s --split-input-file --qcc-verify-connectivity --verify-diagnostics
+
+//===----------------------------------------------------------------------===//
+// Per-site addressability.
+//
+// Co-location is necessary but not sufficient for an entangling gate. On a QCCD
+// machine a storage trap has no gate lasers, so ions there share a motional mode
+// and nothing more; the gate is performed in a dedicated zone.
+//
+// `maxFacetRank` on a site gives the width of the widest operation that site can
+// host; a rank below 2 means it can host none. Omitting it makes the site
+// inherit the device rank, which is the case for a long-chain machine whose trap
+// is also its gate zone.
+//===----------------------------------------------------------------------===//
+
+#h_series = #qcc.device<
+  substrate = #qcc.substrate<
+    sites = [
+      // Storage: holds thirty ions and gates none of them.
+      #qcc.site<name = @storage, kind = trap, capacity = 30, maxFacetRank = 0>,
+      // A junction is a transit site, not a gate site.
+      #qcc.site<name = @j0, kind = junction, capacity = 4, maxFacetRank = 0>,
+      // The only site that can gate. Inherits the device rank of 2.
+      #qcc.site<name = @gate, kind = gatezone, capacity = 2>
+    ],
+    edges = [
+      #qcc.edge<transport, [@storage, @j0], {id = "s_j", bidirectional = true, max_chain_len = 2 : i64}>,
+      #qcc.edge<transport, [@j0, @gate], {id = "j_g", bidirectional = true, max_chain_len = 2 : i64}>
+    ]>,
+  maxFacetRank = 2, downwardClosed = true, partitioning = true, facetOrdering = linear>
+
+// Two ions travel from storage to the gate zone; {0, 1} becomes executable only
+// once they arrive.
+
+func.func @shuttle_to_the_gate_zone(%theta: f64) {
+  %q0 = qc.static 0 : !qc.qubit
+  %q1 = qc.static 1 : !qc.qubit
+
+  %c0 = qcc.config.init(#qcc.placement<
+      @storage = [[0, 1, 2, 3, 4]], @j0 = [], @gate = []>) : !qcc.config<#h_series>
+
+  //   @storage: [0 1] [2 3 4]
+  %c1 = qcc.ion.split %c0 {site = @storage, chain = 0 : i64,
+                           end = #qcc.chain_end<head>, count = 2 : i64} : !qcc.config<#h_series>
+  %c2 = qcc.ion.transport %c1 {from = @storage, chain = 0 : i64, via = "s_j"} : !qcc.config<#h_series>
+  %c3 = qcc.ion.transport %c2 {from = @j0, chain = 0 : i64, via = "j_g"} : !qcc.config<#h_series>
+  //   @gate: [0 1]
+
+  // The same pair now verifies, because of where the ions are.
+  qc.rzz(%theta) %q0, %q1 : !qc.qubit, !qc.qubit
+  return
+}
+
+// -----
+
+#h_series = #qcc.device<
+  substrate = #qcc.substrate<
+    sites = [
+      #qcc.site<name = @storage, kind = trap, capacity = 30, maxFacetRank = 0>,
+      #qcc.site<name = @j0, kind = junction, capacity = 4, maxFacetRank = 0>,
+      #qcc.site<name = @gate, kind = gatezone, capacity = 2>
+    ],
+    edges = [
+      #qcc.edge<transport, [@storage, @j0], {id = "s_j", bidirectional = true, max_chain_len = 2 : i64}>,
+      #qcc.edge<transport, [@j0, @gate], {id = "j_g", bidirectional = true, max_chain_len = 2 : i64}>
+    ]>,
+  maxFacetRank = 2, downwardClosed = true, partitioning = true, facetOrdering = linear>
+
+// Without the shuttle the ions are co-located but still cannot be gated, and the
+// diagnostic distinguishes the two conditions.
+
+func.func @co_located_is_not_enough(%theta: f64) {
+  %q0 = qc.static 0 : !qc.qubit
+  %q1 = qc.static 1 : !qc.qubit
+
+  // expected-note @+1 {{connectivity in force here is defined by this value}}
+  %c = qcc.config.init(#qcc.placement<
+      @storage = [[0, 1, 2, 3, 4]], @j0 = [], @gate = []>) : !qcc.config<#h_series>
+
+  // expected-error @+1 {{the qubits are co-located at @storage, but that site cannot host an entangling gate; they have to be moved to one that can}}
+  qc.rzz(%theta) %q0, %q1 : !qc.qubit, !qc.qubit
+  return
+}
+
+// -----
+
+#h_series = #qcc.device<
+  substrate = #qcc.substrate<
+    sites = [
+      #qcc.site<name = @storage, kind = trap, capacity = 30, maxFacetRank = 0>,
+      #qcc.site<name = @j0, kind = junction, capacity = 4, maxFacetRank = 0>,
+      #qcc.site<name = @gate, kind = gatezone, capacity = 2>
+    ],
+    edges = [
+      #qcc.edge<transport, [@storage, @j0], {id = "s_j", bidirectional = true, max_chain_len = 2 : i64}>,
+      #qcc.edge<transport, [@j0, @gate], {id = "j_g", bidirectional = true, max_chain_len = 2 : i64}>
+    ]>,
+  maxFacetRank = 2, downwardClosed = true, partitioning = true, facetOrdering = linear>
+
+// A junction is a transit site: ions pass through it but are not acted on there.
+func.func @a_junction_is_not_a_gate_zone(%theta: f64) {
+  %q0 = qc.static 0 : !qc.qubit
+  %q1 = qc.static 1 : !qc.qubit
+
+  // expected-note @+1 {{connectivity in force here is defined by this value}}
+  %c = qcc.config.init(#qcc.placement<@storage = [], @j0 = [[0, 1]], @gate = []>)
+      : !qcc.config<#h_series>
+
+  // expected-error @+1 {{the qubits are co-located at @j0, but that site cannot host an entangling gate}}
+  qc.rzz(%theta) %q0, %q1 : !qc.qubit, !qc.qubit
+  return
+}
+
+// -----
+
+// On a long-chain machine the trap is also the gate zone, so it declares no
+// override and inherits the wide device rank.
+
+#long_chain = #qcc.device<
+  substrate = #qcc.substrate<
+    sites = [#qcc.site<name = @trap, kind = trap, capacity = 36>],
+    edges = []>,
+  maxFacetRank = 36, downwardClosed = true, partitioning = true, facetOrdering = linear>
+
+func.func @the_trap_is_the_gate_zone(%theta: f64) {
+  %q0 = qc.static 0 : !qc.qubit
+  %q9 = qc.static 9 : !qc.qubit
+  %c = qcc.config.init(#qcc.placement<@trap = [[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]]>)
+      : !qcc.config<#long_chain>
+  // Opposite ends of one chain. An MS gate couples through the collective
+  // motional mode, so distance along the chain is not a constraint.
+  qc.rzz(%theta) %q0, %q9 : !qc.qubit, !qc.qubit
+  return
+}
+
+// -----
+
+// A site can also be narrower than the device rather than unable to gate: a
+// two-ion gate zone on a machine that elsewhere performs three-body gates. The
+// diagnostic distinguishes a set that is too wide for the site from one that is
+// not a facet at all.
+
+#mixed = #qcc.device<
+  substrate = #qcc.substrate<
+    sites = [#qcc.site<name = @pair_zone, kind = gatezone, capacity = 4, maxFacetRank = 2>],
+    edges = []>,
+  maxFacetRank = 3, downwardClosed = true, partitioning = true, facetOrdering = linear>
+
+func.func @narrower_than_the_device(%theta: f64) {
+  %q0 = qc.static 0 : !qc.qubit
+  %q1 = qc.static 1 : !qc.qubit
+  %q2 = qc.static 2 : !qc.qubit
+
+  // expected-note @+1 {{connectivity in force here is defined by this value}}
+  %c = qcc.config.init(#qcc.placement<@pair_zone = [[0, 1, 2]]>) : !qcc.config<#mixed>
+
+  // A pair is within this zone's rank.
+  qc.rzz(%theta) %q0, %q1 : !qc.qubit, !qc.qubit
+
+  // Three is within the device rank but beyond this zone's.
+  // expected-error @+1 {{facet {0, 1, 2} contains it, but that site hosts operations of at most 2 qubit(s)}}
+  qc.ctrl(%q0, %q1) targets(%t = %q2) { qc.z %t : !qc.qubit
+                                        qc.yield } : {!qc.qubit, !qc.qubit}, {!qc.qubit}
+  return
+}
+
+// -----
+
+// A site cannot host an operation on more qubits than it can hold.
+#over_wide = #qcc.substrate<
+  // expected-error @+1 {{site @gate declares maxFacetRank = 4 but holds at most 2 qubit(s)}}
+  sites = [#qcc.site<name = @gate, kind = gatezone, capacity = 2, maxFacetRank = 4>],
+  edges = []>

--- a/mlir/test/tools/qcc-opt/QCC/qcc-site-geometry-and-ordering.mlir
+++ b/mlir/test/tools/qcc-opt/QCC/qcc-site-geometry-and-ordering.mlir
@@ -1,0 +1,89 @@
+// RUN: qcc-opt %s --split-input-file --qcc-verify-connectivity --verify-diagnostics
+
+//===----------------------------------------------------------------------===//
+// Per-site ordering and geometry.
+//
+// `facetOrdering` and `maxFacetRank` are per-site overrides of the device
+// default, so one machine can hold a linear storage chain alongside an unordered
+// gate zone and a planar crystal. `coords` gives a site a position, which the
+// router uses to prefer a near zone over a far one.
+//===----------------------------------------------------------------------===//
+
+#mixed = #qcc.device<
+  substrate = #qcc.substrate<
+    sites = [
+      // A linear storage chain: splits work here.
+      #qcc.site<name = @store, kind = trap, capacity = 8, coords = [0.000000e+00, 0.000000e+00]>,
+      // A planar crystal in the same machine. Gates on it verify; the chain
+      // rules do not apply, because a plane has no ends.
+      #qcc.site<name = @plane, kind = trap, capacity = 8, facetOrdering = planar,
+                coords = [3.000000e+00, 0.000000e+00]>
+    ],
+    edges = [#qcc.edge<transport, [@store, @plane], {id = "seg", bidirectional = true}>]>,
+  maxFacetRank = 8, downwardClosed = true, partitioning = true, facetOrdering = linear>
+
+// Coordinates survive the round trip, and so does the per-site ordering.
+
+func.func @linear_zone_beside_a_planar_one(%theta: f64) {
+  %q4 = qc.static 4 : !qc.qubit
+  %q6 = qc.static 6 : !qc.qubit
+
+  %c0 = qcc.config.init(#qcc.placement<@store = [[0, 1, 2]], @plane = [[4, 5, 6]]>)
+      : !qcc.config<#mixed>
+
+  // The storage chain is linear, so it can be cut.
+  %c1 = qcc.ion.split %c0 {site = @store, chain = 0 : i64,
+                           end = #qcc.chain_end<head>, count = 1 : i64} : !qcc.config<#mixed>
+
+  // A gate on the planar crystal verifies exactly as anywhere else: `K` only
+  // ever asks a group who is in it, never how they are arranged.
+  qc.rzz(%theta) %q4, %q6 : !qc.qubit, !qc.qubit
+  return
+}
+
+// -----
+
+#mixed = #qcc.device<
+  substrate = #qcc.substrate<
+    sites = [#qcc.site<name = @plane, kind = trap, capacity = 8, facetOrdering = planar>],
+    edges = []>,
+  maxFacetRank = 8, downwardClosed = true, partitioning = true, facetOrdering = linear>
+
+// The chain rules are defined in terms of chain ends, which a plane does not
+// have, so they are rejected on a planar site rather than applied as though the
+// site were linear. A planar rule set would sit alongside the ion rules; none
+// exists, because no platform currently splits or restructures a planar
+// crystal.
+func.func @chain_rules_do_not_apply_to_a_plane() {
+  %c0 = qcc.config.init(#qcc.placement<@plane = [[0, 1, 2]]>) : !qcc.config<#mixed>
+  // expected-error @+1 {{ion.split requires facetOrdering = linear, but @plane is planar}}
+  %c1 = qcc.ion.split %c0 {site = @plane, chain = 0 : i64,
+                           end = #qcc.chain_end<head>, count = 1 : i64} : !qcc.config<#mixed>
+  return
+}
+
+// -----
+
+// The device default applies where a site declares nothing, so a machine that is
+// linear throughout needs no per-site annotation.
+#all_linear = #qcc.device<
+  substrate = #qcc.substrate<
+    sites = [#qcc.site<name = @trap, kind = trap, capacity = 8>],
+    edges = []>,
+  maxFacetRank = 8, downwardClosed = true, partitioning = true, facetOrdering = linear>
+
+func.func @inherited_ordering() {
+  %c0 = qcc.config.init(#qcc.placement<@trap = [[0, 1, 2]]>) : !qcc.config<#all_linear>
+  %c1 = qcc.ion.split %c0 {site = @trap, chain = 0 : i64,
+                           end = #qcc.chain_end<head>, count = 1 : i64} : !qcc.config<#all_linear>
+  return
+}
+
+// -----
+
+// A position has two or three components. Reading the first two of a longer list
+// would mask the error rather than report it.
+#bad_coords = #qcc.substrate<
+  // expected-error @+1 {{site @a declares 4 coordinate(s); a position is 2 or 3 numbers}}
+  sites = [#qcc.site<name = @a, kind = trap, capacity = 4, coords = [1.000000e+00, 2.000000e+00, 3.000000e+00, 4.000000e+00]>],
+  edges = []>

--- a/mlir/test/tools/qcc-opt/QCC/qcc-target-ion-multicore.mlir
+++ b/mlir/test/tools/qcc-opt/QCC/qcc-target-ion-multicore.mlir
@@ -1,0 +1,195 @@
+// RUN: qcc-opt %s --split-input-file --qcc-verify-connectivity --verify-diagnostics
+
+//===----------------------------------------------------------------------===//
+// Trapped ions: a reconfigurable multicore machine with several long chains per
+// module, a junction network for shuttling between them, and a photonic
+// interconnect between modules.
+//
+// Every edge kind the dialect defines is exercised here:
+//
+//   transport  Binary displacement along a segment. Routing between two chains
+//              is several hops through a junction, which is a site of degree 3
+//              rather than an edge of arity 3.
+//   control    Rank-4 AWG groups and rank-2 laser groups over overlapping site
+//              sets. Expanding them into cliques yields one 4-clique and loses
+//              which conflict comes from which resource.
+//   link       A photonic interconnect between modules, forming a facet from
+//              qubits that share no site and that no shuttle could bring
+//              together, since there is no transport path between the modules.
+//   rigid      Absent: on a QCCD machine ions are displaced one chain at a time,
+//              which is why transport here is rank 2.
+//
+// This target is `facetOrdering = linear` and `partitioning = false` at the same
+// time: ordered chains that a split can cut at the ends, with photonic facets
+// laid across them. Tying chain order to partitioning would withdraw the whole
+// ion rule set from a machine with an optical interconnect.
+//===----------------------------------------------------------------------===//
+
+#multicore = #qcc.device<
+  substrate = #qcc.substrate<
+    sites = [
+      // Module A: two storage chains, a junction and a comm zone.
+      #qcc.site<name = @a_c0, kind = trap, capacity = 36>,
+      #qcc.site<name = @a_c1, kind = trap, capacity = 36>,
+      #qcc.site<name = @a_j, kind = junction, capacity = 4>,
+      #qcc.site<name = @a_comm, kind = gatezone, capacity = 2>,
+      // Module B: identical.
+      #qcc.site<name = @b_c0, kind = trap, capacity = 36>,
+      #qcc.site<name = @b_c1, kind = trap, capacity = 36>,
+      #qcc.site<name = @b_j, kind = junction, capacity = 4>,
+      #qcc.site<name = @b_comm, kind = gatezone, capacity = 2>
+    ],
+    edges = [
+      // transport: rank 2 throughout. @a_j has degree 3, that is, three segments
+      // meet there, which is three binary displacements rather than one ternary
+      // edge. Routing @a_c0 to @a_comm is two hops.
+      #qcc.edge<transport, [@a_c0, @a_j], {id = "seg_a_c0j", latency_us = 1.500000e+02, bidirectional = true, max_chain_len = 4 : i64}>,
+      #qcc.edge<transport, [@a_c1, @a_j], {id = "seg_a_c1j", latency_us = 1.500000e+02, bidirectional = true, max_chain_len = 4 : i64}>,
+      #qcc.edge<transport, [@a_j, @a_comm], {id = "seg_a_jm", latency_us = 9.000000e+01, bidirectional = true, max_chain_len = 2 : i64}>,
+      #qcc.edge<transport, [@b_c0, @b_j], {id = "seg_b_c0j", latency_us = 1.500000e+02, bidirectional = true, max_chain_len = 4 : i64}>,
+      #qcc.edge<transport, [@b_c1, @b_j], {id = "seg_b_c1j", latency_us = 1.500000e+02, bidirectional = true, max_chain_len = 4 : i64}>,
+      #qcc.edge<transport, [@b_j, @b_comm], {id = "seg_b_jm", latency_us = 9.000000e+01, bidirectional = true, max_chain_len = 2 : i64}>,
+
+      // There is no transport edge between the modules: an ion cannot be carried
+      // from A to B, and the only way across is the photonic link.
+
+      // link: the photonic interconnect. Rank 2, and `persistent = false`, since
+      // a heralded Bell pair is consumed by use.
+      #qcc.edge<link, [@a_comm, @b_comm], {id = "photon_ab", persistent = false, bell_rate_hz = 1.820000e+02}>,
+
+      // control: two hyperedges over overlapping site sets, from two different
+      // resources. A graph cannot distinguish them.
+      // rank 4: one AWG drives every shuttling electrode in module A, so no two
+      // transports in A may overlap in time, including transports on disjoint
+      // segments, which a placement-only analysis would call parallel.
+      #qcc.edge<control, [@a_c0, @a_c1, @a_j, @a_comm], {id = "awg_a"}>,
+      #qcc.edge<control, [@b_c0, @b_c1, @b_j, @b_comm], {id = "awg_b"}>,
+      // rank 2 over a subset of the same sites: one Raman beam path is switched
+      // between module A's two storage chains, so gates in @a_c0 and @a_c1
+      // serialise even though they share no ion, no segment and no AWG conflict.
+      #qcc.edge<control, [@a_c0, @a_c1], {id = "raman_a"}>,
+      #qcc.edge<control, [@b_c0, @b_c1], {id = "raman_b"}>,
+      // rank 2 spanning the modules: a single heralding detector serves both comm
+      // zones, so the two modules cannot attempt entanglement concurrently.
+      #qcc.edge<control, [@a_comm, @b_comm], {id = "bsa_detector"}>
+    ]>,
+  maxFacetRank = 36,       // full chain addressable in one MS, IonQ Forte scale
+  downwardClosed = true,   // individual addressing: any subset of a chain
+  partitioning = false,    // the photonic facet overlaps the comm-zone chains
+  facetOrdering = linear>  // chains are ordered; splits only at the ends
+
+// A cross-module entanglement, end to end.
+
+func.func @entangle_across_modules(%theta: f64) {
+  %q0 = qc.static 0 : !qc.qubit
+  %q1 = qc.static 1 : !qc.qubit
+  %q2 = qc.static 2 : !qc.qubit
+  %q8 = qc.static 8 : !qc.qubit
+  %q16 = qc.static 16 : !qc.qubit
+
+  // a_c0: [0..7]   a_c1: [8..15]   b_c0: [16..23]   b_c1: [24..31]
+  %c0 = qcc.config.init(#qcc.placement<
+      @a_c0 = [[0, 1, 2, 3, 4, 5, 6, 7]],
+      @a_c1 = [[8, 9, 10, 11, 12, 13, 14, 15]],
+      @a_j = [], @a_comm = [],
+      @b_c0 = [[16, 17, 18, 19, 20, 21, 22, 23]],
+      @b_c1 = [[24, 25, 26, 27, 28, 29, 30, 31]],
+      @b_j = [], @b_comm = []>) : !qcc.config<#multicore>
+
+  // A three-body MS inside chain a_c0. {0, 1, 2} is a face of the facet {0..7};
+  // contiguity is not required, so {0, 4, 7} verifies equally.
+  qc.ctrl(%q0, %q1) targets(%m = %q2) { qc.z %m : !qc.qubit
+                                        qc.yield } : {!qc.qubit, !qc.qubit}, {!qc.qubit}
+
+  // Route ion 0 out of chain a_c0 and into module A's comm zone.
+  %a1 = qcc.ion.split %c0 {site = @a_c0, chain = 0 : i64,
+                           end = #qcc.chain_end<head>, count = 1 : i64} : !qcc.config<#multicore>
+  // Two hops: the junction is traversed by two binary displacements.
+  %a2 = qcc.ion.transport %a1 {from = @a_c0, chain = 0 : i64, via = "seg_a_c0j"} : !qcc.config<#multicore>
+  %a3 = qcc.ion.transport %a2 {from = @a_j, chain = 0 : i64, via = "seg_a_jm"} : !qcc.config<#multicore>
+
+  // The same for ion 16 in module B.
+  %b1 = qcc.ion.split %a3 {site = @b_c0, chain = 0 : i64,
+                           end = #qcc.chain_end<head>, count = 1 : i64} : !qcc.config<#multicore>
+  %b2 = qcc.ion.transport %b1 {from = @b_c0, chain = 0 : i64, via = "seg_b_c0j"} : !qcc.config<#multicore>
+  %b3 = qcc.ion.transport %b2 {from = @b_j, chain = 0 : i64, via = "seg_b_jm"} : !qcc.config<#multicore>
+  // a_c0: [1..7]  a_comm: [0]   b_c0: [17..23]  b_comm: [16]
+
+  // Herald a Bell pair between the two comm zones. No shuttle can achieve this,
+  // since the modules are joined by no transport path. Both parties are routed
+  // into their comm zones first, so the herald depends on the placement the
+  // shuttles produced and the resulting facet depends on the herald.
+  %l0 = qcc.link.generate %b3 {via = "photon_ab", qubits = array<i64: 0, 16>}
+      : !qcc.config<#multicore>
+
+  // Ions 0 and 16 sit in different modules, and {0, 16} is executable.
+  qc.rzz(%theta) %q0, %q16 : !qc.qubit, !qc.qubit
+
+  // Teleporting the gate consumes the pair. The two comm ions are then in
+  // unrelated modules again, and the next cross-module gate heralds afresh.
+  // expected-note @+1 {{connectivity in force here is defined by this value}}
+  %l1 = qcc.link.consume %l0 {qubits = array<i64: 0, 16>} : !qcc.config<#multicore>
+
+  // Ion 0 has left chain a_c0, so a gate legal at %c0 is not legal here. Ion 8 is
+  // in the other chain and never was.
+  // expected-error @+1 {{operand set {0, 8} is not executable in the configuration reaching it: no facet of K contains it}}
+  qc.rzz(%theta) %q0, %q8 : !qc.qubit, !qc.qubit
+
+  return
+}
+
+// -----
+
+// Routing failures the substrate catches on its own.
+
+#multicore = #qcc.device<
+  substrate = #qcc.substrate<
+    sites = [
+      #qcc.site<name = @a_c0, kind = trap, capacity = 36>,
+      #qcc.site<name = @a_j, kind = junction, capacity = 4>,
+      #qcc.site<name = @a_comm, kind = gatezone, capacity = 2>,
+      #qcc.site<name = @b_comm, kind = gatezone, capacity = 2>
+    ],
+    edges = [
+      #qcc.edge<transport, [@a_c0, @a_j], {id = "seg_a_c0j", max_chain_len = 4 : i64}>,
+      #qcc.edge<transport, [@a_j, @a_comm], {id = "seg_a_jm", max_chain_len = 2 : i64}>,
+      #qcc.edge<link, [@a_comm, @b_comm], {id = "photon_ab", persistent = false}>
+    ]>,
+  maxFacetRank = 36, downwardClosed = true, partitioning = false, facetOrdering = linear>
+
+// The interconnect joins @a_comm and @b_comm for the purposes of K only: no ion
+// can travel along it.
+func.func @cannot_shuttle_down_a_fibre() {
+  %c0 = qcc.config.init(#qcc.placement<@a_comm = [[0]]>) : !qcc.config<#multicore>
+  // expected-error @+1 {{substrate declares no transport edge with id 'photon_ab'}}
+  %c1 = qcc.ion.transport %c0 {from = @a_comm, chain = 0 : i64, via = "photon_ab"} : !qcc.config<#multicore>
+  return
+}
+
+// -----
+
+#multicore = #qcc.device<
+  substrate = #qcc.substrate<
+    sites = [
+      #qcc.site<name = @a_c0, kind = trap, capacity = 36>,
+      #qcc.site<name = @a_j, kind = junction, capacity = 4>,
+      #qcc.site<name = @a_comm, kind = gatezone, capacity = 2>
+    ],
+    edges = [
+      #qcc.edge<transport, [@a_c0, @a_j], {id = "seg_a_c0j", max_chain_len = 4 : i64}>,
+      // The segment can carry four ions; the destination cannot hold them.
+      #qcc.edge<transport, [@a_j, @a_comm], {id = "seg_a_jm", max_chain_len = 4 : i64}>
+    ]>,
+  maxFacetRank = 36, downwardClosed = true, partitioning = false, facetOrdering = linear>
+
+// The comm zone holds two ions in flight rather than a chain. Capacity is the
+// transient maximum, and the router must respect it while planning.
+func.func @comm_zone_overflows(%theta: f64) {
+  %q0 = qc.static 0 : !qc.qubit
+  %q1 = qc.static 1 : !qc.qubit
+  %c0 = qcc.config.init(#qcc.placement<@a_j = [[0, 1, 2]], @a_comm = []>) : !qcc.config<#multicore>
+  // expected-error @+1 {{would place 3 qubits at @a_comm, exceeding its capacity of 2}}
+  %c1 = qcc.ion.transport %c0 {from = @a_j, chain = 0 : i64, via = "seg_a_jm"} : !qcc.config<#multicore>
+  qc.rzz(%theta) %q0, %q1 : !qc.qubit, !qc.qubit
+  return
+}

--- a/mlir/test/tools/qcc-opt/QCC/qcc-target-neutral-atoms.mlir
+++ b/mlir/test/tools/qcc-opt/QCC/qcc-target-neutral-atoms.mlir
@@ -1,0 +1,237 @@
+// RUN: qcc-opt %s --split-input-file --qcc-verify-connectivity --verify-diagnostics
+
+//===----------------------------------------------------------------------===//
+// Neutral atoms: a 2x3 SLM trap array under an AOD.
+//
+// This target uses two structures that neither the ion nor the superconducting
+// instantiation does:
+//
+//   * `rigid` edges carry a whole AOD axis. One waveform displaces every atom on
+//     the axis simultaneously, so `qcc.atom.aod_move` is a single rule
+//     application over k sites. The parallelism is stated once in the substrate
+//     and is available to every pass downstream.
+//
+//   * Rydberg blockade discs are `link` edges, which may overlap. An atom in the
+//     middle of the array lies inside several discs, so K records it as a member
+//     of several facets, each of which is available to a gate.
+//     `partitioning = false` records this.
+//
+// The rule set is `qcc.atom.aod_move` and `qcc.atom.slm_transfer`, both checked
+// against the same K that checks every gate.
+//===----------------------------------------------------------------------===//
+
+#atoms = #qcc.device<
+  substrate = #qcc.substrate<
+    // A trap site holds one atom. It is a location rather than a qubit, so the
+    // AOD may hand an atom to a different one.
+    sites = [
+      #qcc.site<name = @t00, kind = trap, capacity = 1>,
+      #qcc.site<name = @t01, kind = trap, capacity = 1>,
+      #qcc.site<name = @t02, kind = trap, capacity = 1>,
+      #qcc.site<name = @t10, kind = trap, capacity = 1>,
+      #qcc.site<name = @t11, kind = trap, capacity = 1>,
+      #qcc.site<name = @t12, kind = trap, capacity = 1>
+    ],
+    edges = [
+      // rigid, rank 3: an AOD row. One waveform moves three atoms in one step.
+      #qcc.edge<rigid, [@t00, @t01, @t02], {id = "aod_row_0", axis = "x", latency_us = 5.000000e+02}>,
+      #qcc.edge<rigid, [@t10, @t11, @t12], {id = "aod_row_1", axis = "x", latency_us = 5.000000e+02}>,
+      // rigid, rank 2: an AOD column.
+      #qcc.edge<rigid, [@t00, @t10], {id = "aod_col_0", axis = "y", latency_us = 5.000000e+02}>,
+      #qcc.edge<rigid, [@t01, @t11], {id = "aod_col_1", axis = "y", latency_us = 5.000000e+02}>,
+      #qcc.edge<rigid, [@t02, @t12], {id = "aod_col_2", axis = "y", latency_us = 5.000000e+02}>,
+
+      // link, rank 4: a Rydberg blockade disc, present whenever the atoms are,
+      // hence `persistent = true`. The two discs share @t01 and @t11, so an atom
+      // at either belongs to both.
+      #qcc.edge<link, [@t00, @t01, @t10, @t11], {id = "blockade_left", persistent = true}>,
+      #qcc.edge<link, [@t01, @t02, @t11, @t12], {id = "blockade_right", persistent = true}>
+    ]>,
+  maxFacetRank = 3,        // multi-qubit Rydberg gates up to 3 atoms
+  downwardClosed = true,   // any subset of a disc may be addressed
+  partitioning = false,    // an atom in the overlap is in two facets at once
+  facetOrdering = none>    // atoms in a disc carry no order
+
+func.func @rigid_row_move(%theta: f64) {
+  %a0 = qc.static 0 : !qc.qubit
+  %a1 = qc.static 1 : !qc.qubit
+  %a2 = qc.static 2 : !qc.qubit
+
+  // Row 0 loaded, row 1 empty.
+  %c0 = qcc.config.init(#qcc.placement<@t00 = [[0]], @t01 = [[1]], @t02 = [[2]]>)
+      : !qcc.config<#atoms>
+
+  // Both inside blockade_left.
+  qc.rzz(%theta) %a0, %a1 : !qc.qubit, !qc.qubit
+  // Atom 1 sits in the overlap, so it pairs to the right as readily as to the
+  // left: one atom in two facets.
+  qc.rzz(%theta) %a1, %a2 : !qc.qubit, !qc.qubit
+
+  // One action moves three atoms one row down. This is why `rigid` is a
+  // hyperedge: moving the row costs what moving one atom costs.
+  // expected-note @+1 {{connectivity in force here is defined by this value}}
+  %c1 = qcc.atom.aod_move %c0 {via = "aod_row_0", to = [@t10, @t11, @t12]}
+      : !qcc.config<#atoms>
+
+  // The discs span both rows, so the row retains its structure and the same pair
+  // remains addressable after the move.
+  qc.rzz(%theta) %a0, %a1 : !qc.qubit, !qc.qubit
+
+  // The two ends of the row lie in different discs both before and after the
+  // move: a rigid displacement moves the atoms, not the blockade geometry.
+  // expected-error @+1 {{operand set {0, 2} is not executable in the configuration reaching it: no facet of K contains it}}
+  qc.rzz(%theta) %a0, %a2 : !qc.qubit, !qc.qubit
+
+  return
+}
+
+// -----
+
+#atoms = #qcc.device<
+  substrate = #qcc.substrate<
+    sites = [
+      #qcc.site<name = @t00, kind = trap, capacity = 1>,
+      #qcc.site<name = @t01, kind = trap, capacity = 1>,
+      #qcc.site<name = @t02, kind = trap, capacity = 1>,
+      #qcc.site<name = @t10, kind = trap, capacity = 1>,
+      #qcc.site<name = @t11, kind = trap, capacity = 1>,
+      #qcc.site<name = @t12, kind = trap, capacity = 1>
+    ],
+    edges = [
+      #qcc.edge<rigid, [@t00, @t01, @t02], {id = "aod_row_0", axis = "x"}>,
+      #qcc.edge<rigid, [@t10, @t11, @t12], {id = "aod_row_1", axis = "x"}>,
+      #qcc.edge<rigid, [@t00, @t10], {id = "aod_col_0", axis = "y"}>,
+      #qcc.edge<rigid, [@t01, @t11], {id = "aod_col_1", axis = "y"}>,
+      #qcc.edge<rigid, [@t02, @t12], {id = "aod_col_2", axis = "y"}>,
+      #qcc.edge<link, [@t00, @t01, @t10, @t11], {id = "blockade_left", persistent = true}>,
+      #qcc.edge<link, [@t01, @t02, @t11, @t12], {id = "blockade_right", persistent = true}>
+    ]>,
+  maxFacetRank = 3, downwardClosed = true, partitioning = false, facetOrdering = none>
+
+// Defect-free assembly: stochastic loading leaves gaps, and the tweezer closes
+// them. The gate the program requires is unavailable in the array as loaded, and
+// one transfer makes it available.
+
+func.func @close_the_gap(%theta: f64) {
+  %a0 = qc.static 0 : !qc.qubit
+  %a1 = qc.static 1 : !qc.qubit
+  %a2 = qc.static 2 : !qc.qubit
+
+  // Loading left a hole at @t01: atom 1 landed one trap too far right.
+  //   blockade_left  = {0, 2}
+  //   blockade_right = {1, 2}
+  %c0 = qcc.config.init(#qcc.placement<@t00 = [[0]], @t02 = [[1]], @t11 = [[2]]>)
+      : !qcc.config<#atoms>
+
+  // Each of these is inside a disc as loaded.
+  qc.rzz(%theta) %a0, %a2 : !qc.qubit, !qc.qubit
+  qc.rzz(%theta) %a1, %a2 : !qc.qubit, !qc.qubit
+
+  // Carry atom 1 one trap left, along the row the tweezer is already on.
+  %c1 = qcc.atom.slm_transfer %c0 {from = @t02, to = @t01} : !qcc.config<#atoms>
+  //   blockade_left  = {0, 1, 2}
+  //   blockade_right = {1, 2}
+
+  // {0, 1} was in no facet before the transfer and is in one now. The gate is
+  // unchanged; the array beneath it is not.
+  qc.rzz(%theta) %a0, %a1 : !qc.qubit, !qc.qubit
+
+  // The three atoms now form a single facet, so one three-atom Rydberg gate
+  // replaces three pairwise gates.
+  qc.ctrl(%a0, %a1) targets(%y = %a2) { qc.z %y : !qc.qubit
+                                        qc.yield } : {!qc.qubit, !qc.qubit}, {!qc.qubit}
+
+  return
+}
+
+// -----
+
+#atoms = #qcc.device<
+  substrate = #qcc.substrate<
+    sites = [
+      #qcc.site<name = @t00, kind = trap, capacity = 1>,
+      #qcc.site<name = @t01, kind = trap, capacity = 1>,
+      #qcc.site<name = @t02, kind = trap, capacity = 1>,
+      #qcc.site<name = @t10, kind = trap, capacity = 1>,
+      #qcc.site<name = @t11, kind = trap, capacity = 1>,
+      #qcc.site<name = @t12, kind = trap, capacity = 1>
+    ],
+    edges = [
+      #qcc.edge<rigid, [@t00, @t01, @t02], {id = "aod_row_0", axis = "x"}>,
+      #qcc.edge<rigid, [@t10, @t11, @t12], {id = "aod_row_1", axis = "x"}>,
+      #qcc.edge<link, [@t00, @t01, @t10, @t11], {id = "blockade_left", persistent = true}>
+    ]>,
+  maxFacetRank = 3, downwardClosed = true, partitioning = false, facetOrdering = none>
+
+// AOD traps are held by a pair of crossed acousto-optic deflectors, and two traps
+// on one axis cannot swap places, since the frequencies addressing them would
+// have to cross. The substrate's site order is the geometric order along the
+// axis, so the check is order preservation.
+func.func @traps_cannot_pass_through_each_other() {
+  %c0 = qcc.config.init(#qcc.placement<@t00 = [[0]], @t01 = [[1]], @t02 = [[2]]>)
+      : !qcc.config<#atoms>
+  // expected-error @+1 {{move is crossing: @t00 and @t01 would swap order on the way to @t12 and @t11}}
+  %c1 = qcc.atom.aod_move %c0 {via = "aod_row_0", to = [@t12, @t11, @t10]}
+      : !qcc.config<#atoms>
+  return
+}
+
+// -----
+
+#atoms = #qcc.device<
+  substrate = #qcc.substrate<
+    sites = [
+      #qcc.site<name = @t00, kind = trap, capacity = 1>,
+      #qcc.site<name = @t01, kind = trap, capacity = 1>,
+      #qcc.site<name = @t02, kind = trap, capacity = 1>,
+      #qcc.site<name = @t10, kind = trap, capacity = 1>,
+      #qcc.site<name = @t11, kind = trap, capacity = 1>,
+      #qcc.site<name = @t12, kind = trap, capacity = 1>
+    ],
+    edges = [
+      #qcc.edge<rigid, [@t00, @t01, @t02], {id = "aod_row_0", axis = "x"}>,
+      #qcc.edge<rigid, [@t10, @t11, @t12], {id = "aod_row_1", axis = "x"}>,
+      #qcc.edge<link, [@t00, @t01, @t10, @t11], {id = "blockade_left", persistent = true}>
+    ]>,
+  maxFacetRank = 3, downwardClosed = true, partitioning = false, facetOrdering = none>
+
+// The row moves as a unit and arrives as a unit, so one occupied destination
+// rejects the whole action. A per-atom model would have to re-derive this
+// constraint for every atom on the axis.
+func.func @the_whole_row_lands_or_none_of_it_does(%theta: f64) {
+  %a0 = qc.static 0 : !qc.qubit
+  %a1 = qc.static 1 : !qc.qubit
+  %c0 = qcc.config.init(#qcc.placement<
+      @t00 = [[0]], @t01 = [[1]], @t02 = [[2]], @t11 = [[3]]>) : !qcc.config<#atoms>
+  // expected-error @+1 {{would place 2 atoms at @t11, exceeding its capacity of 1}}
+  %c1 = qcc.atom.aod_move %c0 {via = "aod_row_0", to = [@t10, @t11, @t12]}
+      : !qcc.config<#atoms>
+  qc.rzz(%theta) %a0, %a1 : !qc.qubit, !qc.qubit
+  return
+}
+
+// -----
+
+#atoms = #qcc.device<
+  substrate = #qcc.substrate<
+    sites = [
+      #qcc.site<name = @t00, kind = trap, capacity = 1>,
+      #qcc.site<name = @t01, kind = trap, capacity = 1>,
+      #qcc.site<name = @t02, kind = trap, capacity = 1>,
+      #qcc.site<name = @t12, kind = trap, capacity = 1>
+    ],
+    edges = [
+      #qcc.edge<rigid, [@t00, @t01, @t02], {id = "aod_row_0", axis = "x"}>,
+      #qcc.edge<rigid, [@t02, @t12], {id = "aod_col_2", axis = "y"}>,
+      #qcc.edge<link, [@t00, @t01], {id = "blockade_left", persistent = true}>
+    ]>,
+  maxFacetRank = 3, downwardClosed = true, partitioning = false, facetOrdering = none>
+
+// A tweezer travels along one axis at a time. @t00 and @t12 share no axis, so the
+// handoff requires two transfers through @t02.
+func.func @a_tweezer_travels_along_an_axis() {
+  %c0 = qcc.config.init(#qcc.placement<@t00 = [[0]]>) : !qcc.config<#atoms>
+  // expected-error @+1 {{no rigid edge is incident to both @t00 and @t12}}
+  %c1 = qcc.atom.slm_transfer %c0 {from = @t00, to = @t12} : !qcc.config<#atoms>
+  return
+}

--- a/mlir/test/tools/qcc-opt/QCC/qcc-target-photonic-modular.mlir
+++ b/mlir/test/tools/qcc-opt/QCC/qcc-target-photonic-modular.mlir
@@ -1,0 +1,223 @@
+// RUN: qcc-opt %s --split-input-file --qcc-verify-connectivity --verify-diagnostics
+
+//===----------------------------------------------------------------------===//
+// Modular and photonic: three modules on an optical switch.
+//
+// This target exercises the component of a configuration that carries
+// entanglement in its own right. A configuration is `C = (pi, <, Lambda)`, whose
+// third component is the set of live entanglement links. A link exists because
+// `qcc.link.generate` heralded it, so it is connectivity the program creates on
+// demand rather than connectivity implied by where the qubits sit.
+//
+// Links are linear resources: `qcc.link.generate` produces one, a teleported gate
+// consumes it, and `qcc.link.consume` records the consumption. K follows: the
+// parties form a facet while the link is live and cease to once it is consumed,
+// so a program that entangles across a fibre twice heralds twice.
+//
+// A `link` edge declares which of two kinds it is. `persistent = true` describes
+// a coupler that exists unconditionally, such as a superconducting resonator or a
+// Rydberg blockade disc. `persistent = false` describes a resource, which
+// contributes to K exactly when one has been generated over it.
+//===----------------------------------------------------------------------===//
+
+#photonic = #qcc.device<
+  substrate = #qcc.substrate<
+    sites = [
+      #qcc.site<name = @m0, kind = module, capacity = 4>,
+      #qcc.site<name = @m1, kind = module, capacity = 4>,
+      #qcc.site<name = @m2, kind = module, capacity = 4>
+    ],
+    edges = [
+      // link, rank 2, consumed by use: a heralded Bell pair over a fibre.
+      #qcc.edge<link, [@m0, @m1], {id = "fibre_01", persistent = false, latency_us = 5.500000e+03}>,
+      #qcc.edge<link, [@m1, @m2], {id = "fibre_12", persistent = false, latency_us = 6.100000e+03}>,
+
+      // The switch is a line: @m0 and @m2 have no fibre between them.
+
+      // control, rank 3: one heralding detector array serves all three modules.
+      // It constrains which entanglement attempts may overlap in time and leaves
+      // K untouched, which is why scheduling structure has an edge kind of its
+      // own rather than being folded into connectivity.
+      #qcc.edge<control, [@m0, @m1, @m2], {id = "bsa_detector"}>
+    ]>,
+  maxFacetRank = 2,        // a fibre yields a Bell pair
+  downwardClosed = true,
+  partitioning = false,    // a live link's facet overlaps both module chains
+  facetOrdering = none>
+
+// A link is heralded, used and consumed.
+
+func.func @herald_use_spend(%theta: f64) {
+  %q0 = qc.static 0 : !qc.qubit
+  %q1 = qc.static 1 : !qc.qubit
+  %q4 = qc.static 4 : !qc.qubit
+
+  %c0 = qcc.config.init(#qcc.placement<
+      @m0 = [[0, 1, 2, 3]],
+      @m1 = [[4, 5, 6, 7]],
+      @m2 = [[8, 9, 10, 11]]>) : !qcc.config<#photonic>
+
+  // Inside one module the qubits are co-located, so the chain is a facet and no
+  // link is required.
+  qc.rzz(%theta) %q0, %q1 : !qc.qubit, !qc.qubit
+
+  // Herald a Bell pair between a qubit in @m0 and one in @m1. Party i occupies
+  // site i of the edge, so the operands are given in the fibre's order.
+  %c1 = qcc.link.generate %c0 {via = "fibre_01", qubits = array<i64: 0, 4>}
+      : !qcc.config<#photonic>
+
+  // {0, 4} is now a facet, and neither qubit moved.
+  qc.rzz(%theta) %q0, %q4 : !qc.qubit, !qc.qubit
+
+  // Teleporting the gate consumes the pair.
+  // expected-note @+1 {{connectivity in force here is defined by this value}}
+  %c2 = qcc.link.consume %c1 {qubits = array<i64: 0, 4>} : !qcc.config<#photonic>
+
+  // The same gate on the same two qubits, which have not moved. The resource is
+  // gone and the facet with it: connectivity that was exhausted rather than
+  // connectivity that moved.
+  // expected-error @+1 {{operand set {0, 4} is not executable in the configuration reaching it: no facet of K contains it}}
+  qc.rzz(%theta) %q0, %q4 : !qc.qubit, !qc.qubit
+
+  return
+}
+
+// -----
+
+#photonic = #qcc.device<
+  substrate = #qcc.substrate<
+    sites = [
+      #qcc.site<name = @m0, kind = module, capacity = 4>,
+      #qcc.site<name = @m1, kind = module, capacity = 4>,
+      #qcc.site<name = @m2, kind = module, capacity = 4>
+    ],
+    edges = [
+      #qcc.edge<link, [@m0, @m1], {id = "fibre_01", persistent = false}>,
+      #qcc.edge<link, [@m1, @m2], {id = "fibre_12", persistent = false}>
+    ]>,
+  maxFacetRank = 2, downwardClosed = true, partitioning = false, facetOrdering = none>
+
+// Several links can be live at once, each forming its own facet.
+
+func.func @two_hops_is_two_links(%theta: f64) {
+  %q0 = qc.static 0 : !qc.qubit
+  %q4 = qc.static 4 : !qc.qubit
+  %q5 = qc.static 5 : !qc.qubit
+  %q8 = qc.static 8 : !qc.qubit
+
+  %c0 = qcc.config.init(#qcc.placement<
+      @m0 = [[0, 1]], @m1 = [[4, 5]], @m2 = [[8, 9]]>) : !qcc.config<#photonic>
+
+  // Both hops are heralded: two live links and two facets, with the middle module
+  // holding one end of each.
+  %c1 = qcc.link.generate %c0 {via = "fibre_01", qubits = array<i64: 0, 4>} : !qcc.config<#photonic>
+  // expected-note @+1 {{connectivity in force here is defined by this value}}
+  %c2 = qcc.link.generate %c1 {via = "fibre_12", qubits = array<i64: 5, 8>} : !qcc.config<#photonic>
+
+  qc.rzz(%theta) %q0, %q4 : !qc.qubit, !qc.qubit
+  qc.rzz(%theta) %q5, %q8 : !qc.qubit, !qc.qubit
+
+  // Two links end to end are not one link. Joining @m0 to @m2 requires an
+  // entanglement swap, which the router emits from the operations above; the
+  // verifier does not treat the path itself as a facet.
+  // expected-error @+1 {{operand set {0, 8} is not executable in the configuration reaching it: no facet of K contains it}}
+  qc.rzz(%theta) %q0, %q8 : !qc.qubit, !qc.qubit
+
+  return
+}
+
+// -----
+
+#photonic = #qcc.device<
+  substrate = #qcc.substrate<
+    sites = [#qcc.site<name = @m0, kind = module, capacity = 4>, #qcc.site<name = @m1, kind = module, capacity = 4>],
+    edges = [#qcc.edge<link, [@m0, @m1], {id = "fibre_01", persistent = false}>]>,
+  maxFacetRank = 2, downwardClosed = true, partitioning = false, facetOrdering = none>
+
+// A link is consumed by use, so consuming one that was never heralded is
+// rejected.
+func.func @a_link_is_heralded_before_it_is_spent(%theta: f64) {
+  %q0 = qc.static 0 : !qc.qubit
+  %q4 = qc.static 4 : !qc.qubit
+  %c0 = qcc.config.init(#qcc.placement<@m0 = [[0]], @m1 = [[4]]>) : !qcc.config<#photonic>
+  // expected-error @+1 {{no live link joins {0, 4} in the configuration reaching this operation}}
+  %c1 = qcc.link.consume %c0 {qubits = array<i64: 0, 4>} : !qcc.config<#photonic>
+  qc.rzz(%theta) %q0, %q4 : !qc.qubit, !qc.qubit
+  return
+}
+
+// -----
+
+#photonic = #qcc.device<
+  substrate = #qcc.substrate<
+    sites = [#qcc.site<name = @m0, kind = module, capacity = 4>, #qcc.site<name = @m1, kind = module, capacity = 4>],
+    edges = [#qcc.edge<link, [@m0, @m1], {id = "fibre_01", persistent = false}>]>,
+  maxFacetRank = 2, downwardClosed = true, partitioning = false, facetOrdering = none>
+
+// A communication qubit holds one pair at a time, so the second herald must wait
+// for the first to be consumed.
+func.func @one_link_per_qubit(%theta: f64) {
+  %q0 = qc.static 0 : !qc.qubit
+  %q4 = qc.static 4 : !qc.qubit
+  %c0 = qcc.config.init(#qcc.placement<@m0 = [[0]], @m1 = [[4, 5]]>) : !qcc.config<#photonic>
+  %c1 = qcc.link.generate %c0 {via = "fibre_01", qubits = array<i64: 0, 4>} : !qcc.config<#photonic>
+  // expected-error @+1 {{qubit 0 already holds a live link}}
+  %c2 = qcc.link.generate %c1 {via = "fibre_01", qubits = array<i64: 0, 5>} : !qcc.config<#photonic>
+  qc.rzz(%theta) %q0, %q4 : !qc.qubit, !qc.qubit
+  return
+}
+
+// -----
+
+#photonic = #qcc.device<
+  substrate = #qcc.substrate<
+    sites = [#qcc.site<name = @m0, kind = module, capacity = 4>, #qcc.site<name = @m1, kind = module, capacity = 4>],
+    edges = [#qcc.edge<link, [@m0, @m1], {id = "fibre_01", persistent = false}>]>,
+  maxFacetRank = 2, downwardClosed = true, partitioning = false, facetOrdering = none>
+
+// The photon leaves the module its emitter is in, so party i must occupy site i
+// of the fibre.
+func.func @a_party_sits_at_its_end_of_the_fibre(%theta: f64) {
+  %q0 = qc.static 0 : !qc.qubit
+  %q1 = qc.static 1 : !qc.qubit
+  %c0 = qcc.config.init(#qcc.placement<@m0 = [[0, 1]], @m1 = [[4]]>) : !qcc.config<#photonic>
+  // expected-error @+1 {{qubit 1 sits at @m0, but link edge 'fibre_01' expects that party at @m1}}
+  %c1 = qcc.link.generate %c0 {via = "fibre_01", qubits = array<i64: 0, 1>} : !qcc.config<#photonic>
+  qc.rzz(%theta) %q0, %q1 : !qc.qubit, !qc.qubit
+  return
+}
+
+// -----
+
+// The same edge kind covers the permanent case. With `persistent = true` the
+// coupler exists unconditionally: it is a facet from the start, with nothing to
+// herald and nothing to exhaust.
+#superconducting = #qcc.device<
+  substrate = #qcc.substrate<
+    sites = [#qcc.site<name = @q0, kind = fixed, capacity = 1>, #qcc.site<name = @q1, kind = fixed, capacity = 1>],
+    edges = [#qcc.edge<link, [@q0, @q1], {id = "coupler_01", persistent = true}>]>,
+  maxFacetRank = 2, downwardClosed = true, partitioning = false, facetOrdering = none>
+
+func.func @a_coupler_needs_no_heralding(%theta: f64) {
+  %q0 = qc.static 0 : !qc.qubit
+  %q1 = qc.static 1 : !qc.qubit
+  %c0 = qcc.config.init(#qcc.placement<@q0 = [[0]], @q1 = [[1]]>) : !qcc.config<#superconducting>
+  // Legal immediately, with no rule applied.
+  qc.rzz(%theta) %q0, %q1 : !qc.qubit, !qc.qubit
+  return
+}
+
+// -----
+
+#superconducting = #qcc.device<
+  substrate = #qcc.substrate<
+    sites = [#qcc.site<name = @q0, kind = fixed, capacity = 1>, #qcc.site<name = @q1, kind = fixed, capacity = 1>],
+    edges = [#qcc.edge<link, [@q0, @q1], {id = "coupler_01", persistent = true}>]>,
+  maxFacetRank = 2, downwardClosed = true, partitioning = false, facetOrdering = none>
+
+func.func @a_coupler_is_not_a_resource() {
+  %c0 = qcc.config.init(#qcc.placement<@q0 = [[0]], @q1 = [[1]]>) : !qcc.config<#superconducting>
+  // expected-error @+1 {{link edge 'coupler_01' is persistent, so it is available without being generated}}
+  %c1 = qcc.link.generate %c0 {via = "coupler_01", qubits = array<i64: 0, 1>} : !qcc.config<#superconducting>
+  return
+}

--- a/mlir/test/tools/qcc-opt/QCC/qcc-transport-doors.mlir
+++ b/mlir/test/tools/qcc-opt/QCC/qcc-transport-doors.mlir
@@ -1,0 +1,196 @@
+// RUN: qcc-opt %s --split-input-file --qcc-verify-connectivity --verify-diagnostics
+
+//===----------------------------------------------------------------------===//
+// Segment ends: which end of a trap a segment reaches.
+//
+// A trap holds a line of ions and a segment joins it at one end. Only the chain
+// at that end can leave; anything further in would have to pass through the ions
+// in front of it.
+//
+// `ends` declares the reached ends, one entry per incident site in the edge's
+// own order. A site's chain list is maintained in spatial order, since a split
+// leaves the detached part on the side it came from, so the reachable chain is
+// either the first or the last index, and the same property positions arrivals.
+//
+// The machine below has two traps of ten ions each. The segment reaches the head
+// of @trap_1 and the tail of @trap_2, so an ion may leave @trap_1 only from the
+// head and @trap_2 only from the tail, one at a time.
+//===----------------------------------------------------------------------===//
+
+#two = #qcc.device<
+  substrate = #qcc.substrate<
+    sites = [
+      #qcc.site<name = @trap_1, kind = trap, capacity = 12>,
+      #qcc.site<name = @trap_2, kind = trap, capacity = 12>
+    ],
+    edges = [
+      #qcc.edge<transport, [@trap_1, @trap_2],
+                {id = "seg", ends = ["head", "tail"], latency_us = 8.000000e+01,
+                 bidirectional = true, max_chain_len = 1 : i64}>
+    ]>,
+  maxFacetRank = 10, downwardClosed = true, partitioning = true, facetOrdering = linear>
+
+// The legal move: detach the head ion of @trap_1 and carry it across.
+
+func.func @leftmost_ion_leaves(%theta: f64) {
+  %q0 = qc.static 0 : !qc.qubit
+  %q19 = qc.static 19 : !qc.qubit
+
+  %c0 = qcc.config.init(#qcc.placement<
+      @trap_1 = [[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]],
+      @trap_2 = [[10, 11, 12, 13, 14, 15, 16, 17, 18, 19]]>) : !qcc.config<#two>
+
+  // Detach one ion from the head, which is the end the segment reaches.
+  //   @trap_1: [0] [1 2 3 4 5 6 7 8 9]
+  %c1 = qcc.ion.split %c0 {site = @trap_1, chain = 0 : i64,
+                           end = #qcc.chain_end<head>, count = 1 : i64} : !qcc.config<#two>
+
+  // Chain 0 is at the head, so it can leave. It enters @trap_2 through the tail
+  // and lands on the tail:
+  //   @trap_2: [10 .. 19] [0]
+  %c2 = qcc.ion.transport %c1 {from = @trap_1, chain = 0 : i64, via = "seg"} : !qcc.config<#two>
+
+  %c3 = qcc.ion.merge %c2 {site = @trap_2, dst = 0 : i64, src = 1 : i64,
+                           at = #qcc.chain_end<tail>} : !qcc.config<#two>
+  //   @trap_2: [10 .. 19 0]
+
+  qc.rzz(%theta) %q0, %q19 : !qc.qubit, !qc.qubit
+  return
+}
+
+// -----
+
+#two = #qcc.device<
+  substrate = #qcc.substrate<
+    sites = [
+      #qcc.site<name = @trap_1, kind = trap, capacity = 12>,
+      #qcc.site<name = @trap_2, kind = trap, capacity = 12>
+    ],
+    edges = [
+      #qcc.edge<transport, [@trap_1, @trap_2],
+                {id = "seg", ends = ["head", "tail"], bidirectional = true, max_chain_len = 1 : i64}>
+    ]>,
+  maxFacetRank = 10, downwardClosed = true, partitioning = true, facetOrdering = linear>
+
+// An arrival lands at the end it entered through, so it can leave again along
+// the same segment. Ion 0 enters @trap_2 through the tail, and the return
+// journey is legal only because it landed on the tail.
+
+func.func @an_arrival_can_go_home(%theta: f64) {
+  %q0 = qc.static 0 : !qc.qubit
+  %q1 = qc.static 1 : !qc.qubit
+
+  %c0 = qcc.config.init(#qcc.placement<
+      @trap_1 = [[0, 1, 2]], @trap_2 = [[10, 11]]>) : !qcc.config<#two>
+
+  %c1 = qcc.ion.split %c0 {site = @trap_1, chain = 0 : i64,
+                           end = #qcc.chain_end<head>, count = 1 : i64} : !qcc.config<#two>
+  //   @trap_1: [0] [1 2]   ->   @trap_2: [10 11] [0]
+  %c2 = qcc.ion.transport %c1 {from = @trap_1, chain = 0 : i64, via = "seg"} : !qcc.config<#two>
+
+  // Chain 1 is at @trap_2's tail, which is the end the segment reaches. Had the
+  // arrival landed at the head, this would be rejected.
+  %c3 = qcc.ion.transport %c2 {from = @trap_2, chain = 1 : i64, via = "seg"} : !qcc.config<#two>
+  //   back to @trap_1 through its head, so it lands at the head again
+  %c4 = qcc.ion.merge %c3 {site = @trap_1, dst = 1 : i64, src = 0 : i64,
+                           at = #qcc.chain_end<head>} : !qcc.config<#two>
+
+  qc.rzz(%theta) %q0, %q1 : !qc.qubit, !qc.qubit
+  return
+}
+
+// -----
+
+#two = #qcc.device<
+  substrate = #qcc.substrate<
+    sites = [
+      #qcc.site<name = @trap_1, kind = trap, capacity = 12>,
+      #qcc.site<name = @trap_2, kind = trap, capacity = 12>
+    ],
+    edges = [
+      #qcc.edge<transport, [@trap_1, @trap_2],
+                {id = "seg", ends = ["head", "tail"], bidirectional = true, max_chain_len = 1 : i64}>
+    ]>,
+  maxFacetRank = 10, downwardClosed = true, partitioning = true, facetOrdering = linear>
+
+// Detaching the tail ion of @trap_1 is expressible but strands it: it ends up at
+// the end opposite the segment and can no longer reach it.
+
+func.func @the_rightmost_ion_is_stranded(%theta: f64) {
+  %q9 = qc.static 9 : !qc.qubit
+  %q10 = qc.static 10 : !qc.qubit
+
+  %c0 = qcc.config.init(#qcc.placement<
+      @trap_1 = [[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]],
+      @trap_2 = [[10, 11]]>) : !qcc.config<#two>
+
+  //   @trap_1: [0 .. 8] [9]   -- ion 9 is chain 1, at the far end
+  %c1 = qcc.ion.split %c0 {site = @trap_1, chain = 0 : i64,
+                           end = #qcc.chain_end<tail>, count = 1 : i64} : !qcc.config<#two>
+  // expected-error @+1 {{chain 1 is not at the door: segment 'seg' meets @trap_1 at its head end, so only chain 0 can leave; the 1 chain(s) in between would have to be moved first}}
+  %c2 = qcc.ion.transport %c1 {from = @trap_1, chain = 1 : i64, via = "seg"} : !qcc.config<#two>
+
+  qc.rzz(%theta) %q9, %q10 : !qc.qubit, !qc.qubit
+  return
+}
+
+// -----
+
+#two = #qcc.device<
+  substrate = #qcc.substrate<
+    sites = [
+      #qcc.site<name = @trap_1, kind = trap, capacity = 12>,
+      #qcc.site<name = @trap_2, kind = trap, capacity = 12>
+    ],
+    edges = [
+      #qcc.edge<transport, [@trap_1, @trap_2],
+                {id = "seg", ends = ["head", "tail"], bidirectional = true, max_chain_len = 4 : i64}>
+    ]>,
+  maxFacetRank = 10, downwardClosed = true, partitioning = true, facetOrdering = linear>
+
+// The same rule from the other side: a chain cannot be moved out past one
+// sitting between it and the segment.
+
+func.func @nothing_moves_past_the_ion_in_front(%theta: f64) {
+  %q1 = qc.static 1 : !qc.qubit
+  %q10 = qc.static 10 : !qc.qubit
+
+  %c0 = qcc.config.init(#qcc.placement<@trap_1 = [[0, 1, 2]], @trap_2 = [[10]]>)
+      : !qcc.config<#two>
+
+  //   @trap_1: [0] [1 2]
+  %c1 = qcc.ion.split %c0 {site = @trap_1, chain = 0 : i64,
+                           end = #qcc.chain_end<head>, count = 1 : i64} : !qcc.config<#two>
+  // Ion 0 sits between chain 1 and the segment.
+  // expected-error @+1 {{chain 1 is not at the door: segment 'seg' meets @trap_1 at its head end, so only chain 0 can leave}}
+  %c2 = qcc.ion.transport %c1 {from = @trap_1, chain = 1 : i64, via = "seg"} : !qcc.config<#two>
+
+  qc.rzz(%theta) %q1, %q10 : !qc.qubit, !qc.qubit
+  return
+}
+
+// -----
+
+// The property's shape is verified, since a mismatched list would silently
+// associate the wrong end with the wrong trap.
+
+#wrong_arity = #qcc.substrate<
+  sites = [#qcc.site<name = @a, kind = trap, capacity = 4>, #qcc.site<name = @b, kind = trap, capacity = 4>],
+  // expected-error @+1 {{`ends` has 1 entry but the edge is incident to 2 site(s); give one end per endpoint}}
+  edges = [#qcc.edge<transport, [@a, @b], {id = "seg", ends = ["head"]}>]>
+
+// -----
+
+#wrong_value = #qcc.substrate<
+  sites = [#qcc.site<name = @a, kind = trap, capacity = 4>, #qcc.site<name = @b, kind = trap, capacity = 4>],
+  // expected-error @+1 {{`ends` entries must be "head" or "tail"}}
+  edges = [#qcc.edge<transport, [@a, @b], {id = "seg", ends = ["left", "right"]}>]>
+
+// -----
+
+// Reached ends are a property of a segment. A control group has no ends, so
+// declaring them there is an error rather than a no-op.
+#wrong_kind = #qcc.substrate<
+  sites = [#qcc.site<name = @a, kind = trap, capacity = 4>, #qcc.site<name = @b, kind = trap, capacity = 4>],
+  // expected-error @+1 {{`ends` is only meaningful on a transport edge}}
+  edges = [#qcc.edge<control, [@a, @b], {id = "awg", ends = ["head", "tail"]}>]>

--- a/mlir/test/tools/qcc-opt/QCC/qcc-verify-connectivity-errors.mlir
+++ b/mlir/test/tools/qcc-opt/QCC/qcc-verify-connectivity-errors.mlir
@@ -1,0 +1,263 @@
+// RUN: qcc-opt %s --qcc-verify-connectivity --split-input-file --verify-diagnostics
+
+//===----------------------------------------------------------------------===//
+// Negative tests for the verifier. Each of these programs would be accepted by a
+// dialect modelling connectivity as a static coupling graph, which cannot express
+// why they are ill-formed.
+//===----------------------------------------------------------------------===//
+
+#ion = #qcc.device<
+  substrate = #qcc.substrate<
+    sites = [
+      #qcc.site<name = @trap_a, kind = trap, capacity = 6>,
+      #qcc.site<name = @trap_b, kind = trap, capacity = 6>,
+      #qcc.site<name = @j0, kind = junction, capacity = 4>
+    ],
+    edges = [
+      #qcc.edge<transport, [@trap_a, @j0], {id = "seg_aj", latency_us = 8.000000e+01, max_chain_len = 2 : i64}>,
+      #qcc.edge<transport, [@j0, @trap_b], {id = "seg_jb", latency_us = 8.000000e+01, bidirectional = false}>
+    ]>,
+  maxFacetRank = 5, downwardClosed = true, partitioning = true, facetOrdering = linear>
+
+// Ions 0 and 5 sit in different traps, so no facet of K contains both. A fixed
+// coupling graph cannot make this check, since the answer depends on where the
+// ions currently are.
+func.func @not_colocated(%theta: f64) {
+  %q0 = qc.static 0 : !qc.qubit
+  %q5 = qc.static 5 : !qc.qubit
+  // expected-note @+1 {{connectivity in force here is defined by this value}}
+  %c = qcc.config.init(#qcc.placement<@trap_a = [[0, 1, 2]], @trap_b = [[5, 6]]>)
+      : !qcc.config<#ion>
+  // expected-error @+1 {{operand set {0, 5} is not executable in the configuration reaching it: no facet of K contains it; the facets here are {0, 1, 2}, {5, 6}}}
+  qc.rxx(%theta) %q0, %q5 : !qc.qubit, !qc.qubit
+  return
+}
+
+// -----
+
+#ion = #qcc.device<
+  substrate = #qcc.substrate<
+    sites = [#qcc.site<name = @trap_a, kind = trap, capacity = 6>],
+    edges = []>,
+  maxFacetRank = 5, downwardClosed = true, partitioning = true, facetOrdering = linear>
+
+// The same two qubits are legal before the split and illegal after it. Nothing
+// about the gate changes; the configuration dominating it does.
+func.func @split_invalidates_a_later_gate(%theta: f64) {
+  %q0 = qc.static 0 : !qc.qubit
+  %q1 = qc.static 1 : !qc.qubit
+  %c0 = qcc.config.init(#qcc.placement<@trap_a = [[0, 1, 2]]>) : !qcc.config<#ion>
+  qc.rxx(%theta) %q0, %q1 : !qc.qubit, !qc.qubit
+  // @trap_a: [0 1 2] -> [0] [1 2]
+  // expected-note @+1 {{connectivity in force here is defined by this value}}
+  %c1 = qcc.ion.split %c0 {site = @trap_a, chain = 0 : i64,
+                           end = #qcc.chain_end<head>, count = 1 : i64} : !qcc.config<#ion>
+  // expected-error @+1 {{operand set {0, 1} is not executable in the configuration reaching it}}
+  qc.rxx(%theta) %q0, %q1 : !qc.qubit, !qc.qubit
+  return
+}
+
+// -----
+
+#ion = #qcc.device<
+  substrate = #qcc.substrate<
+    sites = [#qcc.site<name = @trap_a, kind = trap, capacity = 6>],
+    edges = []>,
+  maxFacetRank = 5, downwardClosed = true, partitioning = true, facetOrdering = linear>
+
+// An unplaced qubit: the gate names a hardware qubit the configuration does not
+// mention.
+func.func @qubit_not_placed(%theta: f64) {
+  %q0 = qc.static 0 : !qc.qubit
+  %q9 = qc.static 9 : !qc.qubit
+  %c = qcc.config.init(#qcc.placement<@trap_a = [[0, 1, 2]]>) : !qcc.config<#ion>
+  // expected-error @+1 {{acts on qubit 9, which the configuration reaching it does not place}}
+  qc.rxx(%theta) %q0, %q9 : !qc.qubit, !qc.qubit
+  return
+}
+
+// -----
+
+// A machine offering only a global MS gate acts on a chain as a whole or not at
+// all. `downwardClosed = false` rules out representing K by its facets alone, and
+// is why a subset check is insufficient.
+#global_ms = #qcc.device<
+  substrate = #qcc.substrate<
+    sites = [#qcc.site<name = @trap_a, kind = trap, capacity = 6>],
+    edges = []>,
+  maxFacetRank = 5, downwardClosed = false, partitioning = true, facetOrdering = linear>
+
+func.func @not_downward_closed(%theta: f64) {
+  %q0 = qc.static 0 : !qc.qubit
+  %q1 = qc.static 1 : !qc.qubit
+  // expected-note @+1 {{connectivity in force here is defined by this value}}
+  %c = qcc.config.init(#qcc.placement<@trap_a = [[0, 1, 2]]>) : !qcc.config<#global_ms>
+  // expected-error @+1 {{the device is not downward closed, so facet {0, 1, 2} must be acted on whole rather than in part}}
+  qc.rxx(%theta) %q0, %q1 : !qc.qubit, !qc.qubit
+  return
+}
+
+// -----
+
+#ion = #qcc.device<
+  substrate = #qcc.substrate<
+    sites = [
+      #qcc.site<name = @trap_a, kind = trap, capacity = 6>,
+      #qcc.site<name = @trap_b, kind = trap, capacity = 6>,
+      #qcc.site<name = @j0, kind = junction, capacity = 4>
+    ],
+    edges = [
+      #qcc.edge<transport, [@trap_a, @j0], {id = "seg_aj", max_chain_len = 2 : i64}>,
+      #qcc.edge<transport, [@j0, @trap_b], {id = "seg_jb", bidirectional = false}>
+    ]>,
+  maxFacetRank = 5, downwardClosed = true, partitioning = true, facetOrdering = linear>
+
+// There is no transport edge directly from @trap_a to @trap_b. The junction is a
+// site of degree 2 rather than a ternary edge, so the route is two binary hops.
+func.func @no_such_segment() {
+  %q0 = qc.static 0 : !qc.qubit
+  %c0 = qcc.config.init(#qcc.placement<@trap_a = [[0, 1]]>) : !qcc.config<#ion>
+  // expected-error @+1 {{substrate declares no transport edge with id 'seg_ab'}}
+  %c1 = qcc.ion.transport %c0 {from = @trap_a, chain = 0 : i64, via = "seg_ab"} : !qcc.config<#ion>
+  return
+}
+
+// -----
+
+#ion = #qcc.device<
+  substrate = #qcc.substrate<
+    sites = [
+      #qcc.site<name = @trap_a, kind = trap, capacity = 6>,
+      #qcc.site<name = @trap_b, kind = trap, capacity = 6>,
+      #qcc.site<name = @j0, kind = junction, capacity = 4>
+    ],
+    edges = [
+      #qcc.edge<transport, [@trap_a, @j0], {id = "seg_aj", max_chain_len = 2 : i64}>,
+      #qcc.edge<transport, [@j0, @trap_b], {id = "seg_jb", bidirectional = false}>
+    ]>,
+  maxFacetRank = 5, downwardClosed = true, partitioning = true, facetOrdering = linear>
+
+// @seg_jb is declared one-way from @j0 to @trap_b.
+func.func @against_the_declared_direction() {
+  %c0 = qcc.config.init(#qcc.placement<@trap_b = [[0, 1]]>) : !qcc.config<#ion>
+  // expected-error @+1 {{transport edge 'seg_jb' is unidirectional from @j0 to @trap_b, but this operation traverses it the other way}}
+  %c1 = qcc.ion.transport %c0 {from = @trap_b, chain = 0 : i64, via = "seg_jb"} : !qcc.config<#ion>
+  return
+}
+
+// -----
+
+#ion = #qcc.device<
+  substrate = #qcc.substrate<
+    sites = [
+      #qcc.site<name = @trap_a, kind = trap, capacity = 6>,
+      #qcc.site<name = @j0, kind = junction, capacity = 4>
+    ],
+    edges = [
+      #qcc.edge<transport, [@trap_a, @j0], {id = "seg_aj", max_chain_len = 2 : i64}>
+    ]>,
+  maxFacetRank = 5, downwardClosed = true, partitioning = true, facetOrdering = linear>
+
+// A configuration-dependent failure, reported when the rule is applied rather
+// than by the operation's own verifier.
+func.func @chain_too_long_for_the_segment(%theta: f64) {
+  %q0 = qc.static 0 : !qc.qubit
+  %q1 = qc.static 1 : !qc.qubit
+  %c0 = qcc.config.init(#qcc.placement<@trap_a = [[0, 1, 2]]>) : !qcc.config<#ion>
+  // expected-error @+1 {{chain of length 3 exceeds the max_chain_len of 2 declared by segment 'seg_aj'}}
+  %c1 = qcc.ion.transport %c0 {from = @trap_a, chain = 0 : i64, via = "seg_aj"} : !qcc.config<#ion>
+  qc.rxx(%theta) %q0, %q1 : !qc.qubit, !qc.qubit
+  return
+}
+
+// -----
+
+#ion = #qcc.device<
+  substrate = #qcc.substrate<
+    sites = [
+      #qcc.site<name = @trap_a, kind = trap, capacity = 6>,
+      #qcc.site<name = @j0, kind = junction, capacity = 2>
+    ],
+    edges = [
+      #qcc.edge<transport, [@trap_a, @j0], {id = "seg_aj"}>
+    ]>,
+  maxFacetRank = 5, downwardClosed = true, partitioning = true, facetOrdering = linear>
+
+// Capacity is the transient maximum, and a junction has very little of it.
+func.func @junction_overflows(%theta: f64) {
+  %q0 = qc.static 0 : !qc.qubit
+  %q1 = qc.static 1 : !qc.qubit
+  %c0 = qcc.config.init(#qcc.placement<@trap_a = [[0, 1, 2]], @j0 = []>) : !qcc.config<#ion>
+  // expected-error @+1 {{would place 3 qubits at @j0, exceeding its capacity of 2}}
+  %c1 = qcc.ion.transport %c0 {from = @trap_a, chain = 0 : i64, via = "seg_aj"} : !qcc.config<#ion>
+  qc.rxx(%theta) %q0, %q1 : !qc.qubit, !qc.qubit
+  return
+}
+
+// -----
+
+#ion = #qcc.device<
+  substrate = #qcc.substrate<
+    sites = [#qcc.site<name = @trap_a, kind = trap, capacity = 6>],
+    edges = []>,
+  maxFacetRank = 5, downwardClosed = true, partitioning = true, facetOrdering = linear>
+
+// A split must leave ions on both sides. Detaching the whole chain would produce
+// an empty potential well.
+func.func @split_leaves_nothing(%theta: f64) {
+  %q0 = qc.static 0 : !qc.qubit
+  %q1 = qc.static 1 : !qc.qubit
+  %c0 = qcc.config.init(#qcc.placement<@trap_a = [[0, 1]]>) : !qcc.config<#ion>
+  // expected-error @+1 {{cannot detach 2 ion(s) from a chain of length 2}}
+  %c1 = qcc.ion.split %c0 {site = @trap_a, chain = 0 : i64,
+                           end = #qcc.chain_end<head>, count = 2 : i64} : !qcc.config<#ion>
+  qc.rxx(%theta) %q0, %q1 : !qc.qubit, !qc.qubit
+  return
+}
+
+// -----
+
+// A target whose facets carry no order has no chain ends, so detaching at an end
+// is undefined there rather than unrestricted.
+#unordered = #qcc.device<
+  substrate = #qcc.substrate<
+    sites = [#qcc.site<name = @zone, kind = gatezone, capacity = 6>],
+    edges = []>,
+  maxFacetRank = 5, downwardClosed = true, partitioning = true, facetOrdering = none>
+
+func.func @split_needs_an_order() {
+  %c0 = qcc.config.init(#qcc.placement<@zone = [[0, 1, 2]]>) : !qcc.config<#unordered>
+  // expected-error @+1 {{ion.split requires facetOrdering = linear}}
+  %c1 = qcc.ion.split %c0 {site = @zone, chain = 0 : i64,
+                           end = #qcc.chain_end<head>, count = 1 : i64} : !qcc.config<#unordered>
+  return
+}
+
+// -----
+
+#ion = #qcc.device<
+  substrate = #qcc.substrate<
+    sites = [#qcc.site<name = @trap_a, kind = trap, capacity = 6>],
+    edges = []>,
+  maxFacetRank = 5, downwardClosed = true, partitioning = true, facetOrdering = linear>
+
+// The loop-carried case: the body's net rewrite is not the identity, so no single
+// placement describes this program point. The pass reports it rather than
+// deciding it.
+func.func @loop_carried_configuration(%theta: f64, %n: index) {
+  %q0 = qc.static 0 : !qc.qubit
+  %q1 = qc.static 1 : !qc.qubit
+  %lb = arith.constant 0 : index
+  %step = arith.constant 1 : index
+  %c0 = qcc.config.init(#qcc.placement<@trap_a = [[0, 1, 2, 3]]>) : !qcc.config<#ion>
+
+  %cN = scf.for %i = %lb to %n step %step iter_args(%c = %c0) -> (!qcc.config<#ion>) {
+    %ca = qcc.ion.split %c {site = @trap_a, chain = 0 : i64,
+                            end = #qcc.chain_end<head>, count = 1 : i64} : !qcc.config<#ion>
+    // expected-error @+2 {{the configuration reaching this operation is not statically known}}
+    // expected-note @+1 {{statically known only if the body's net rewrite is the identity}}
+    qc.rxx(%theta) %q0, %q1 : !qc.qubit, !qc.qubit
+    scf.yield %ca : !qcc.config<#ion>
+  }
+  return
+}

--- a/mlir/test/tools/qcc-opt/QCC/qcc-verify-connectivity.mlir
+++ b/mlir/test/tools/qcc-opt/QCC/qcc-verify-connectivity.mlir
@@ -1,0 +1,132 @@
+// RUN: qcc-opt %s --qcc-verify-connectivity | FileCheck %s
+
+//===----------------------------------------------------------------------===//
+// The same two-qubit gate on the same two qubits is legal at one program point
+// and illegal at another. Nothing about the gate changes; only the configuration
+// dominating it does.
+//===----------------------------------------------------------------------===//
+
+#ion = #qcc.device<
+  substrate = #qcc.substrate<
+    sites = [
+      #qcc.site<name = @trap_a, kind = trap, capacity = 20>,
+      #qcc.site<name = @trap_b, kind = trap, capacity = 20>,
+      #qcc.site<name = @j0, kind = junction, capacity = 10>
+    ],
+    edges = [
+      #qcc.edge<transport, [@trap_a, @j0], {id = "seg_aj", latency_us = 8.000000e+01, bidirectional = true, max_chain_len = 10 : i64}>,
+      #qcc.edge<transport, [@j0, @trap_b], {id = "seg_jb", latency_us = 8.000000e+01, bidirectional = true, max_chain_len = 10 : i64}>,
+      #qcc.edge<control, [@trap_a, @j0, @trap_b], {id = "awg_shuttle"}>
+    ]>,
+  maxFacetRank = 10,
+  downwardClosed = true,   // individual addressing: any subset of a chain
+  partitioning = true,     // every ion sits in exactly one chain
+  facetOrdering = linear>  // chains are ordered; splits only at the ends
+
+// CHECK-LABEL: func.func @shuttle_then_entangle
+func.func @shuttle_then_entangle(%theta: f64) {
+  %q0 = qc.static 0 : !qc.qubit
+  %q1 = qc.static 1 : !qc.qubit
+  %q5 = qc.static 5 : !qc.qubit
+  %q6 = qc.static 6 : !qc.qubit
+
+  %c0 = qcc.config.init(#qcc.placement<
+      @trap_a = [[0, 1, 2, 3, 4]],
+      @trap_b = [[5, 6, 7, 8, 9]],
+      @j0     = []>) : !qcc.config<#ion>
+
+  // {0, 1} is a face of the facet {0..4}. Contiguity is not required: with
+  // individual addressing, {0, 4} verifies equally.
+  // CHECK: qc.rxx
+  qc.rxx(%theta) %q0, %q1 : !qc.qubit, !qc.qubit
+  // {5, 6} is a face of the other facet.
+  // CHECK: qc.rxx
+  qc.rxx(%theta) %q5, %q6 : !qc.qubit, !qc.qubit
+
+  // Now move ion 0 across the junction into trap_b.
+  %c1 = qcc.ion.split %c0 {site = @trap_a, chain = 0 : i64,
+                           end = #qcc.chain_end<head>, count = 1 : i64} : !qcc.config<#ion>
+  %c2 = qcc.ion.transport %c1 {from = @trap_a, chain = 0 : i64, via = "seg_aj"} : !qcc.config<#ion>
+  %c3 = qcc.ion.transport %c2 {from = @j0, chain = 0 : i64, via = "seg_jb"} : !qcc.config<#ion>
+  %c4 = qcc.ion.merge %c3 {site = @trap_b, dst = 0 : i64, src = 1 : i64,
+                           at = #qcc.chain_end<head>} : !qcc.config<#ion>
+  // @trap_a: [1 2 3 4]   @trap_b: [0 5 6 7 8 9]
+
+  // {0, 5} is executable here and was not under %c0. The converse holds for
+  // {0, 1}, which is why the gates above are ordered before the split.
+  // CHECK: qc.rxx
+  qc.rxx(%theta) %q0, %q5 : !qc.qubit, !qc.qubit
+
+  // A single-qubit gate is a local rotation: it needs the qubit placed, not
+  // co-located with anything.
+  // CHECK: qc.h
+  qc.h %q1 : !qc.qubit
+
+  // A controlled gate is an interaction between every qubit it names, controls
+  // included, so it is checked as the composite set {0, 5}.
+  // CHECK: qc.ctrl
+  qc.ctrl(%q0) targets(%a0 = %q5) {
+    qc.x %a0 : !qc.qubit
+    qc.yield
+  } : {!qc.qubit}, {!qc.qubit}
+
+  return
+}
+
+//===----------------------------------------------------------------------===//
+// A function containing no configuration is not checked, so the pass is safe in
+// a pipeline that also compiles programs with no target attached.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: func.func @no_target_declared
+func.func @no_target_declared() {
+  %q0 = qc.static 0 : !qc.qubit
+  %q9 = qc.static 9 : !qc.qubit
+  // Would be rejected under #ion; here there is no connectivity in force.
+  // CHECK: qc.swap
+  qc.swap %q0, %q9 : !qc.qubit, !qc.qubit
+  return
+}
+
+//===----------------------------------------------------------------------===//
+// A superconducting target has an empty rule set, so no operation can produce a
+// new configuration and K is a fixed coupling graph. Couplers are link edges,
+// whose facets do not partition the qubits: q1 belongs to both {q0, q1} and
+// {q1, q2}.
+//===----------------------------------------------------------------------===//
+
+#sc = #qcc.device<
+  substrate = #qcc.substrate<
+    sites = [
+      #qcc.site<name = @q0, kind = fixed, capacity = 1>,
+      #qcc.site<name = @q1, kind = fixed, capacity = 1>,
+      #qcc.site<name = @q2, kind = fixed, capacity = 1>
+    ],
+    edges = [
+      #qcc.edge<link, [@q0, @q1], {id = "coupler_01", persistent = true}>,
+      #qcc.edge<link, [@q1, @q2], {id = "coupler_12", persistent = true}>
+    ]>,
+  maxFacetRank = 2,
+  downwardClosed = true,
+  partitioning = false,
+  facetOrdering = none>
+
+// CHECK-LABEL: func.func @coupling_graph
+func.func @coupling_graph() {
+  %q0 = qc.static 0 : !qc.qubit
+  %q1 = qc.static 1 : !qc.qubit
+  %q2 = qc.static 2 : !qc.qubit
+
+  %c = qcc.config.init(#qcc.placement<@q0 = [[0]], @q1 = [[1]], @q2 = [[2]]>)
+      : !qcc.config<#sc>
+
+  // Both couplers exist, so both CZs verify. {0, 2} does not; see the negative
+  // tests.
+  // CHECK-COUNT-2: qc.z
+  qc.ctrl(%q0) targets(%a = %q1) { qc.z %a : !qc.qubit
+                                   qc.yield } : {!qc.qubit}, {!qc.qubit}
+  qc.ctrl(%q1) targets(%b = %q2) { qc.z %b : !qc.qubit
+                                   qc.yield } : {!qc.qubit}, {!qc.qubit}
+
+  return
+}

--- a/mlir/test/tools/qcc-opt/QCC/qcc-workflow-check-and-optimize.mlir
+++ b/mlir/test/tools/qcc-opt/QCC/qcc-workflow-check-and-optimize.mlir
@@ -1,0 +1,93 @@
+// RUN: qcc-opt %s --split-input-file --qcc-verify-connectivity --qcc-optimize-shuttling 2>/dev/null | FileCheck %s
+// RUN: qcc-opt %s --split-input-file --qcc-verify-connectivity --qcc-optimize-shuttling 2>&1 >/dev/null | FileCheck %s --check-prefix=REMARK
+
+//===----------------------------------------------------------------------===//
+// Workflow 2: a hardware-aware program, checked and then optimised.
+//
+// The input already carries its own machine and its own shuttling schedule, as a
+// hand-written or externally generated program does. The compiler does not decide
+// where the qubits go; it confirms that the schedule is legal and then makes it
+// cheaper without changing what the program computes.
+//===----------------------------------------------------------------------===//
+
+#ion = #qcc.device<
+  substrate = #qcc.substrate<
+    sites = [
+      #qcc.site<name = @trap_a, kind = trap, capacity = 6>,
+      #qcc.site<name = @trap_b, kind = trap, capacity = 6>
+    ],
+    edges = [
+      #qcc.edge<transport, [@trap_a, @trap_b], {id = "seg", latency_us = 8.000000e+01, bidirectional = true, max_chain_len = 4 : i64}>
+    ]>,
+  maxFacetRank = 5, downwardClosed = true, partitioning = true, facetOrdering = linear>
+
+// CHECK-LABEL: func.func @hand_written_schedule
+func.func @hand_written_schedule(%theta: f64) {
+  %q0 = qc.static 0 : !qc.qubit
+  %q1 = qc.static 1 : !qc.qubit
+  %q2 = qc.static 2 : !qc.qubit
+
+  %c0 = qcc.config.init(#qcc.placement<@trap_a = [[0, 1, 2]], @trap_b = []>)
+      : !qcc.config<#ion>
+
+  // Legal against the configuration in force, so verification leaves it alone.
+  // CHECK: qc.rzz
+  qc.rzz(%theta) %q0, %q1 : !qc.qubit, !qc.qubit
+
+  // Ion 0 travels to @trap_b and returns. Nothing is executed in between or
+  // afterwards, so the round trip costs 160 us of machine time for no observable
+  // effect.
+  %c1 = qcc.ion.split %c0 {site = @trap_a, chain = 0 : i64,
+                           end = #qcc.chain_end<head>, count = 1 : i64} : !qcc.config<#ion>
+  %c2 = qcc.ion.transport %c1 {from = @trap_a, chain = 0 : i64, via = "seg"} : !qcc.config<#ion>
+  %c3 = qcc.ion.transport %c2 {from = @trap_b, chain = 0 : i64, via = "seg"} : !qcc.config<#ion>
+  %c4 = qcc.ion.merge %c3 {site = @trap_a, dst = 0 : i64, src = 1 : i64,
+                           at = #qcc.chain_end<head>} : !qcc.config<#ion>
+
+  // REMARK: remark: dropped 4 unobserved rewrite(s), saving 1.600000e+02 us
+  // CHECK-NOT: qcc.ion.
+  return
+}
+
+// -----
+
+#ion = #qcc.device<
+  substrate = #qcc.substrate<
+    sites = [
+      #qcc.site<name = @trap_a, kind = trap, capacity = 6>,
+      #qcc.site<name = @trap_b, kind = trap, capacity = 6>
+    ],
+    edges = [
+      #qcc.edge<transport, [@trap_a, @trap_b], {id = "seg", latency_us = 8.000000e+01, bidirectional = true, max_chain_len = 4 : i64}>
+    ]>,
+  maxFacetRank = 5, downwardClosed = true, partitioning = true, facetOrdering = linear>
+
+//===----------------------------------------------------------------------===//
+// Motion a later gate depends on is retained. The pass removes only what nothing
+// observes, so a schedule whose shuttles are all required passes through
+// unchanged.
+//===----------------------------------------------------------------------===//
+
+// CHECK-LABEL: func.func @every_shuttle_is_load_bearing
+func.func @every_shuttle_is_load_bearing(%theta: f64) {
+  %q0 = qc.static 0 : !qc.qubit
+  %q3 = qc.static 3 : !qc.qubit
+
+  %c0 = qcc.config.init(#qcc.placement<@trap_a = [[0, 1, 2]], @trap_b = [[3, 4]]>)
+      : !qcc.config<#ion>
+
+  // CHECK: qcc.ion.split
+  %c1 = qcc.ion.split %c0 {site = @trap_a, chain = 0 : i64,
+                           end = #qcc.chain_end<head>, count = 1 : i64} : !qcc.config<#ion>
+  // CHECK: qcc.ion.transport
+  %c2 = qcc.ion.transport %c1 {from = @trap_a, chain = 0 : i64, via = "seg"} : !qcc.config<#ion>
+  // CHECK: qcc.ion.merge
+  %c3 = qcc.ion.merge %c2 {site = @trap_b, dst = 0 : i64, src = 1 : i64,
+                           at = #qcc.chain_end<head>} : !qcc.config<#ion>
+
+  // This gate requires all three rewrites above: without them ions 0 and 3 are in
+  // different traps and {0, 3} is in no facet.
+  // CHECK: qc.rzz
+  qc.rzz(%theta) %q0, %q3 : !qc.qubit, !qc.qubit
+  return
+}

--- a/mlir/test/tools/qcc-opt/QCC/qcc-workflow-fit-to-device.mlir
+++ b/mlir/test/tools/qcc-opt/QCC/qcc-workflow-fit-to-device.mlir
@@ -1,0 +1,75 @@
+// RUN: qcc-opt %s --qcc-attach-device=device=sc-grid-4x4 --qcc-place-qubits | FileCheck %s --check-prefix=SC
+// RUN: qcc-opt %s --qcc-attach-device=device=sc-grid-4x4 --qcc-place-qubits --qcc-route=emit-remarks=true 2>&1 | FileCheck %s --check-prefix=SC-ROUTE
+// RUN: qcc-opt %s --qcc-attach-device=device=qccd-linear-2 --qcc-place-qubits | FileCheck %s --check-prefix=ION
+// RUN: qcc-opt %s --qcc-attach-device=device=qccd-linear-2 --qcc-place-qubits --qcc-route --qcc-verify-connectivity | FileCheck %s --check-prefix=ION-OK
+// RUN: not qcc-opt %s --qcc-attach-device=device=nonexistent 2>&1 | FileCheck %s --check-prefix=UNKNOWN
+
+//===----------------------------------------------------------------------===//
+// Workflow 1: a hardware-agnostic program fitted to a named machine.
+//
+// The input describes no device: no configuration, no substrate, only gates on
+// hardware qubits. `--qcc-attach-device` records which machine to compile for,
+// and `--qcc-place-qubits` decides where the qubits start out on it. Everything
+// after that is the same dialect the hardware-aware workflow uses.
+//
+// The same input is fitted below to two machines with different outcomes, which
+// is what keeping the machine out of the program allows.
+//===----------------------------------------------------------------------===//
+
+func.func @agnostic(%theta: f64) {
+  %q0 = qc.static 0 : !qc.qubit
+  %q1 = qc.static 1 : !qc.qubit
+  %q5 = qc.static 5 : !qc.qubit
+
+  qc.rzz(%theta) %q0, %q1 : !qc.qubit, !qc.qubit
+  qc.rzz(%theta) %q0, %q5 : !qc.qubit, !qc.qubit
+  return
+}
+
+//===----------------------------------------------------------------------===//
+// Superconducting: capacity-1 sites, so placement is the identity mapping and the
+// coupling map is derived from the machine's reported couplings.
+//===----------------------------------------------------------------------===//
+
+// The reported coupling map becomes persistent link edges.
+// SC-DAG: #qcc.edge<link, [@q0, @q1], {id = "coupler_q0_q1", persistent = true}>
+// SC-DAG: #qcc.edge<link, [@q0, @q4], {id = "coupler_q0_q4", persistent = true}>
+// SC-DAG: module attributes {qcc.device = #{{.+}}}
+// SC-LABEL: func.func @agnostic
+// Sites the program does not use are listed too, so the initial configuration
+// describes the whole machine.
+// SC: qcc.config.init(#qcc.placement<@q0 = {{\[\[}}0]], @q1 = {{\[\[}}1]], @q2 = {{\[\[}}5]], @q3 = [],
+
+// The first gate lands on a coupled pair and the second does not. On a machine
+// with no rewrite rules the only remedy is SWAP insertion, which the router
+// reports.
+// SC-ROUTE: remark: needs routing: {0, 5} is not executable here
+// SC-ROUTE: note: currently 0 at @q0, 5 at @q2
+// SC-ROUTE: note: this machine has no rewrite rules, so no shuttle can fix it
+
+//===----------------------------------------------------------------------===//
+// Trapped ions: a trap is a zone, so placement packs all three qubits into the
+// first one and co-location makes both gates executable without routing. The
+// program itself is unchanged.
+//===----------------------------------------------------------------------===//
+
+// The supplement supplies what a coupling map cannot express: the segments and
+// the waveform generator that serialises them.
+// ION-DAG: #qcc.edge<transport, [@trap_a, @j0], {bidirectional = true, id = "seg_aj"
+// ION-DAG: #qcc.edge<control, [@trap_a, @j0, @trap_b], {id = "awg_shuttle"}>
+// ION-DAG: module attributes {qcc.device = #{{.+}}}
+// ION-LABEL: func.func @agnostic
+// ION: qcc.config.init(#qcc.placement<@trap_a = {{\[\[}}0, 1, 5]], @j0 = [], @trap_b = []>)
+
+// Routing and verification both pass, so the pipeline runs to completion.
+// ION-OK-LABEL: func.func @agnostic
+// ION-OK-COUNT-2: qc.rzz
+
+//===----------------------------------------------------------------------===//
+// An unknown machine name is rejected with the list of machines this build
+// knows.
+//===----------------------------------------------------------------------===//
+
+// UNKNOWN: unknown machine 'nonexistent'; this build knows
+// UNKNOWN-SAME: sc-grid-4x4
+// UNKNOWN-SAME: qccd-linear-2

--- a/mlir/test/tools/qcc/cli-options/list-devices.test
+++ b/mlir/test/tools/qcc/cli-options/list-devices.test
@@ -1,0 +1,17 @@
+// RUN: qcc --list-devices | FileCheck %s
+
+// `--target` and `--device` are two axes: a backend decides how code is
+// emitted, a machine decides where it runs. They are listed separately so that
+// nothing suggests picking one constrains the other.
+
+// Each machine also reports how the compiler represents a configuration over
+// it, which is derived from its declared properties rather than stated. The
+// four cases are distinct across the library, so a misclassification shows up
+// here rather than as a silent change of checking strategy.
+
+// CHECK: Available machines for --device:
+// CHECK-DAG: sc-grid-4x4 - Superconducting{{.*}}[static]
+// CHECK-DAG: qccd-linear-2 - Trapped-ion QCCD{{.*}}[ordered-partition]
+// CHECK-DAG: qccd-storage-gate - Trapped-ion QCCD{{.*}}[ordered-partition]
+// CHECK-DAG: neutral-atom-3x3 - Neutral atoms{{.*}}[injection]
+// CHECK-DAG: modular-photonic-3 - Three modules on an optical switch{{.*}}[explicit-incidence]

--- a/mlir/tools/qcc-opt/CMakeLists.txt
+++ b/mlir/tools/qcc-opt/CMakeLists.txt
@@ -20,6 +20,7 @@ target_link_libraries(
           MLIROpenMPDialect
           QCCJaspDialect
           QCCAuxDialect
+          QCCQCCDialect
           # Passes
           MLIRMemRefTransforms
           MLIRArithTransforms
@@ -33,6 +34,7 @@ target_link_libraries(
           QCCToQIR
           QCCAuxOutputRecording
           QCCAffineRaise
+          QCCQCCTransforms
           # Extensions/Interfaces
           MLIRFuncInlinerExtension
           MLIRTransformUtils

--- a/mlir/tools/qcc-opt/qcc-opt.cpp
+++ b/mlir/tools/qcc-opt/qcc-opt.cpp
@@ -14,6 +14,8 @@
 #include "qcc/Conversion/ToQIR/ToQIR.h"
 #include "qcc/Dialect/Aux_/IR/Aux_.h"
 #include "qcc/Dialect/Jasp/IR/Jasp.h"
+#include "qcc/Dialect/QCC/IR/QCC.h"
+#include "qcc/Dialect/QCC/Transforms/Passes.h"
 
 #include "mlir/Conversion/ArithToLLVM/ArithToLLVM.h"
 #include "mlir/Conversion/FuncToLLVM/ConvertFuncToLLVM.h"
@@ -66,7 +68,8 @@ int main(int argc, char** argv) {
     mlir::DLTIDialect,
     jasp::JaspDialect,
     mlir::qc::QCDialect,
-    qcc::aux::AuxDialect
+    qcc::aux::AuxDialect,
+    qcc::conn::QCCDialect
       // clang-format on
       >();
 
@@ -99,6 +102,12 @@ int main(int argc, char** argv) {
   mlir::registerConvertFuncToLLVMPass();
   qcc::registerConvertQIRToHiSEPQIntrinsics();
   qcc::registerEmitHiSEPQStart();
+  qcc::registerVerifyConnectivity();
+  qcc::registerAttachDevice();
+  qcc::registerPlaceQubits();
+  qcc::registerRoute();
+  qcc::registerOptimizeShuttling();
+  qcc::registerScheduleConcurrency();
 
   // Extension registration
   mlir::arith::registerBufferizableOpInterfaceExternalModels(registry);

--- a/mlir/tools/qcc/CMakeLists.txt
+++ b/mlir/tools/qcc/CMakeLists.txt
@@ -21,7 +21,8 @@ set(LIBS
     MLIRBuiltinToLLVMIRTranslation
     MLIRLLVMToLLVMIRTranslation
     QCCCompiler
-    QCCTarget)
+    QCCTarget
+    QCCQCCDevices)
 
 add_llvm_executable(qcc qcc.cpp DEPENDS ${LIBS})
 

--- a/mlir/tools/qcc/qcc.cpp
+++ b/mlir/tools/qcc/qcc.cpp
@@ -7,9 +7,12 @@
 //
 // ===----------------------------------------------------------------------===//
 
+#include "qcc/Dialect/QCC/IR/QCC.h"
+
 #include "qcc/Compiler/Compiler.h"
 #include "qcc/Dialect/Aux_/IR/Aux_.h"
 #include "qcc/Dialect/Jasp/IR/Jasp.h"
+#include "qcc/Dialect/QCC/Devices/DeviceLibrary.h"
 #include "qcc/Target/TargetRegistry.h"
 
 #include "mlir/Bytecode/BytecodeWriter.h"
@@ -64,6 +67,26 @@ static void printTargets() {
   }
 }
 
+/// `--target` and `--device` are two different axes, and listing them
+/// separately is the clearest way to say so: a backend decides how code is
+/// emitted, a device decides which machine it runs on.
+static void printDevices() {
+  // Building each description costs a context, but it is what reports the
+  // representation, and the representation is what says how the compiler models
+  // the machine rather than merely what the machine is called.
+  mlir::MLIRContext context;
+  context.loadDialect<qcc::conn::QCCDialect>();
+
+  llvm::outs() << "Available machines for --device:\n";
+  for (const qcc::conn::DeviceEntry& machine : qcc::conn::getDevices()) {
+    llvm::outs() << "  " << machine.name << " - " << machine.description;
+    if (const auto device = machine.build(&context)) {
+      llvm::outs() << " [" << qcc::conn::stringifyRepresentation(device.getRepresentation()) << "]";
+    }
+    llvm::outs() << "\n";
+  }
+}
+
 int main(int argc, char** argv) {
   mlir::registerMLIRContextCLOptions();
   mlir::registerPassManagerCLOptions();
@@ -75,6 +98,8 @@ int main(int argc, char** argv) {
   const cl::opt<std::string> targetName("target", cl::desc("Target backend to compile for (see --list-targets)"),
                                         cl::init("qir"), cl::value_desc("name"), cl::cat(qccCategory));
   const cl::opt<bool> listTargets("list-targets", cl::desc("List the available --target backends and exit"),
+                                  cl::init(false), cl::cat(qccCategory));
+  const cl::opt<bool> listDevices("list-devices", cl::desc("List the machines known to --device and exit"),
                                   cl::init(false), cl::cat(qccCategory));
   const cl::opt<Stage> compileTo(
       "compile-to", cl::desc("Stage to lower to and emit"), cl::init(Stage::LlvmIr),
@@ -89,6 +114,11 @@ int main(int argc, char** argv) {
 
   if (listTargets) {
     printTargets();
+    return 0;
+  }
+
+  if (listDevices) {
+    printDevices();
     return 0;
   }
 


### PR DESCRIPTION
A dialect to encode hardware constraints and connectivity of the physical machine. The main problem is to design a dialect that is general enough to accommodate any platform and that can also represent the quirks of a particular device. For this reason, we envision a four layer structure that represents the share properties of hardware platforms:

**Layer 0**: The hardware device. Represented as a graph $P = (N, E)$. The nodes represent a physical site where qubits can **possibly** be located, while the edges represent the **possible** interactions that can happen between sites (like transport if qubits can be shuttled or link if the qubits can interact). As this represents the physical hardware, it is fixed and represented as an attribute in the dialect.

**Layer 1**: The configuration of the qubits. A mapping from the qubits to the sites of the hardware device. $\pi: Q \to N$. This maps can change through the program. The configuration constitute a type for each hardware device. A value of that type constitutes a particular instance of a machine.

**Layer 2**: The interaction set (possibly a complex) given by $$K(\pi) \subseteq 2^Q$$. It is obtained from the actual configuration and from the capabilities of the hardware device. The entire interaction set is never stored (as it could be huge) but rather the question that if a number of qubit could interact is answer by knowing this information.

**Layer 3**: A rule set $R$ of operation that can be performed on the configuration given the capabilities of the hardware. The operations are modelled, naturally, as MLIR ops.

The statement is that this can model a general quantum hardware as it basically abstract away the two things that every hardware posses: the qubits and the possible interactions between them. By decoupling the hardware device of its configuration we can easily model dynamically changing hardware configurations. 

The actual PR is work in progress and we are in the planning and discussion phase. @RiccardoRomanello, @julfarn, @rainij 